### PR TITLE
Migrate to Pydantic v2, enhance tests, and update documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install pytest pydantic
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -39,6 +39,8 @@ tests/
 
 `conftest.py` uses `unittest.mock.MagicMock` to stub out Home Assistant, bleak, paho-mqtt, and other runtime dependencies so the pydantic data models can be tested in isolation.
 
+For a detailed list of all tests and what they verify, see [TESTS.md](TESTS.md).
+
 ## Architecture Overview
 
 See [README.md](README.md) for user-facing docs. Key modules:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,53 @@
+# Developer Guide
+
+## Prerequisites
+
+- Python 3.13+ (tested on 3.14)
+- pip
+
+## Setup
+
+```bash
+pip install pytest pydantic
+```
+
+> **Note:** You do _not_ need Home Assistant installed to run the model tests. The test suite mocks all HA dependencies.
+
+## Running Tests
+
+```bash
+# All tests
+python -m pytest tests/ -v
+
+# Specific test file
+python -m pytest tests/test_dp_models.py -v
+python -m pytest tests/test_models.py -v
+
+# Single test class or method
+python -m pytest tests/test_dp_models.py::TestCleaningStatus -v
+python -m pytest tests/test_models.py::TestCommand::test_get_dps_as_keyed_dict -v
+```
+
+## Test Structure
+
+```
+tests/
+├── conftest.py          # Fixtures + mocked HA/BLE/MQTT dependencies
+├── test_dp_models.py    # Data Point models (DP, CleaningStatus, Battery, etc.)
+└── test_models.py       # API/MQTT response models (Command, Device, Group, etc.)
+```
+
+`conftest.py` uses `unittest.mock.MagicMock` to stub out Home Assistant, bleak, paho-mqtt, and other runtime dependencies so the pydantic data models can be tested in isolation.
+
+## Architecture Overview
+
+See [README.md](README.md) for user-facing docs. Key modules:
+
+| Module | Role |
+|--------|------|
+| `wybot_dp_models.py` | Data Point classes (protocol layer) |
+| `wybot_models.py` | Pydantic models for HTTP/MQTT API responses |
+| `wybot_coordinator.py` | DataUpdateCoordinator (BLE-first, MQTT fallback) |
+| `wybot_ble_client.py` | BLE communication (AA55 binary protocol) |
+| `wybot_mqtt_client.py` | MQTT pub/sub client |
+| `wybot_http_client.py` | REST API client |

--- a/README.md
+++ b/README.md
@@ -1,34 +1,101 @@
-# WyBot For HomeAssistant
+# WyBot for Home Assistant
 
 [![GitHub release](https://img.shields.io/github/v/release/bassrock/hass-wybot?style=for-the-badge)](http://github.com/bassrock/hass-wybot/releases/latest)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
+[![Python](https://img.shields.io/badge/python-3.13%2B-blue?style=for-the-badge)](https://www.python.org)
 
-A Home Assistant custom integration to interact with [WyBot's Pool vacumms](https://www.wybotpool.com/) which allows controlling of WyBot pool vaccums as Vacumm entities in HomeAssistant.
+A Home Assistant custom integration for [WyBot pool vacuums](https://www.wybotpool.com/). Control your pool robot as a Vacuum entity with real-time status, battery monitoring, and solar dock tracking.
 
-Note: This has only been tested with 1 S2 Pro with the docking station and requires the use of the Cloud API which connects to WyBot's MQTT broker for communication with the Robot.
+## Features
+
+- **Vacuum entity** — Start, stop, return to dock, and select cleaning mode
+- **7 cleaning modes** — Floor, Wall, Wall Then Floor, Advanced Full Pool, Water Line, Turbo Floor, Eco Floor
+- **Battery monitoring** — Robot battery level and charging status
+- **Solar dock support** — Dock battery level, solar charging status, and total energy harvested
+- **BLE-first architecture** — Uses local Bluetooth when available, falls back to cloud MQTT
+- **Bluetooth discovery** — Automatically detects DS20 docks via BLE
+- **Diagnostic sensors** — Data source (BLE/MQTT), last communication timestamps
+
+## Tested Devices
+
+| Device | Status |
+|--------|--------|
+| S2 Pro + DS20 Solar Dock | ✅ Tested |
+| C1 | ✅ Tested |
+| Other WyBot models | Should work — please report issues |
+
+## Entities
+
+The integration creates the following entities per device:
+
+### Vacuum
+| Entity | Description |
+|--------|-------------|
+| Vacuum | Start/stop/return to dock, cleaning mode selection |
+
+### Sensors
+| Entity | Description |
+|--------|-------------|
+| Robot battery | Battery level (%) |
+| Dock battery | Solar dock battery level (%) |
+| Energy harvested | Total solar energy (Wh) |
+| Dock type | Standard or Solar |
+| Data source | Current connection method (Bluetooth / Cloud) |
+| Last BLE communication | Timestamp of last Bluetooth poll |
+| Last MQTT communication | Timestamp of last cloud message |
+
+### Binary Sensors
+| Entity | Description |
+|--------|-------------|
+| Robot charging | Whether the robot is charging |
+| Dock charging | Whether the solar panel is actively charging |
+
+### Buttons
+| Entity | Description |
+|--------|-------------|
+| Send WiFi credentials | Send WiFi config to dock via BLE (diagnostic, disabled by default) |
 
 ## Installation
 
-The easiest way to install this integration is by using [HACS](https://hacs.xyz).
-
-If you have HACS installed, you can add the Vantage integration by using this My button:
+### HACS (recommended)
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=bassrock&repository=hass-wybot&category=integration)
 
-<details>
-<summary>
-<h4>Manual installation</h4>
-</summary>
+### Manual
 
-If you aren't using HACS, you can download the [latest release](https://github.com/bassrock/hass-wybot/releases/latest/download/hass-wybot.zip) and extract the contents to your Home Assistant `config/custom_components` directory.
-</details>
+Download the [latest release](https://github.com/bassrock/hass-wybot/releases/latest/download/hass-wybot.zip) and extract to your `config/custom_components` directory.
 
-## Setting up a WyBot S2 Pro with a Dock
+## Configuration
 
-WyBots disconnect from WiFI when they are in the water. However if you have a dock, the dock will stay connected to WiFi and relay commands underwater to the WyBot. HOWEVER, the order you setup the Dock & Wybot matter. YOU MUST first setup the dock, and connect it to WiFi then pair your robot with it. There is no way to set the wifi on the Dock after you setup the WyBot.
+1. Go to **Settings → Devices & Services → Add Integration**
+2. Search for **WyBot**
+3. Enter your WyBot account email and password
+4. (Optional) Enter WiFi SSID and password for manual dock provisioning via BLE
 
-## Future
+> **Bluetooth discovery:** If you have a DS20 dock in Bluetooth range, Home Assistant will automatically detect it and prompt you to set up the integration.
 
-* Better connection handling with MQTT
-* Enabling Bluetooth communication
-* Testing with more robots.
+## How It Works
+
+The integration uses a **BLE-first with MQTT fallback** architecture:
+
+1. **Bluetooth (primary)** — Polls the dock via BLE every 30 seconds for instant local status updates
+2. **Cloud MQTT (fallback)** — If BLE fails or the device is out of range, connects to WyBot's MQTT broker
+3. **HTTP API** — Used for initial device discovery and session keepalive
+
+Commands (start, stop, return to dock) are also sent via BLE first, falling back to MQTT if needed.
+
+## Setting Up a WyBot S2 Pro with a Dock
+
+> **⚠️ Important:** The dock must be set up **before** the robot. You must first set up the dock and connect it to WiFi, then pair the robot with it. There is no way to configure WiFi on the dock after the robot has been paired.
+
+WyBot robots disconnect from WiFi when submerged. The dock stays connected to WiFi and relays commands to the robot underwater via Bluetooth.
+
+## Contributing
+
+See [DEVELOPER.md](DEVELOPER.md) for instructions on running tests and an overview of the codebase architecture.
+
+## Roadmap
+
+- Better MQTT connection handling
+- Testing with more robot models
+- Bluetooth-only operation (no cloud dependency)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Home Assistant custom integration for [WyBot pool vacuums](https://www.wybotpo
 | Device | Status |
 |--------|--------|
 | S2 Pro + DS20 Solar Dock | ✅ Tested |
-| C1 | ✅ Tested |
+| C1 | 🔄 Testing in progress |
 | Other WyBot models | Should work — please report issues |
 
 ## Entities

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Home Assistant custom integration for [WyBot pool vacuums](https://www.wybotpo
 | Device | Status |
 |--------|--------|
 | S2 Pro + DS20 Solar Dock | ✅ Tested |
-| C1 | 🔄 Testing in progress |
+| C1 | ✅ Tested |
 | Other WyBot models | Should work — please report issues |
 
 ## Entities
@@ -89,6 +89,16 @@ Commands (start, stop, return to dock) are also sent via BLE first, falling back
 > **⚠️ Important:** The dock must be set up **before** the robot. You must first set up the dock and connect it to WiFi, then pair the robot with it. There is no way to configure WiFi on the dock after the robot has been paired.
 
 WyBot robots disconnect from WiFi when submerged. The dock stays connected to WiFi and relays commands to the robot underwater via Bluetooth.
+
+## Blueprints
+
+A comprehensive "All-in-One" automation blueprint is included in the `blueprints/` directory:
+
+| Blueprint | Description |
+|-----------|-------------|
+| **WyBot: Pool Robot Notifications & Schedule** | A powerful multi-function blueprint that handles cleaning completion notifications, full charge alerts, low battery warnings, and daily cleaning schedules with mode selection and battery checks. |
+
+To import the blueprint, copy `blueprints/wybot_all_in_one.yaml` to your Home Assistant `config/blueprints/automation/wybot/` directory, or use the **Import Blueprint** feature in the HA UI.
 
 ## Contributing
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,181 @@
+# Test Reference
+
+76 tests across 2 test files. Run with `python -m pytest tests/ -v`.
+
+## test_dp_models.py — Data Point Models (47 tests)
+
+### TestDP — Pydantic DP model
+| Test | Description |
+|------|-------------|
+| `test_create_full` | Create DP with all fields |
+| `test_create_query_only` | Create DP with only `id` (query mode) |
+| `test_create_from_dict` | Create DP via `model_validate()` |
+| `test_serialization` | `model_dump()` roundtrip |
+
+### TestGenericDP — Base DP wrapper class
+| Test | Description |
+|------|-------------|
+| `test_init_from_dp` | Initialize from DP pydantic model |
+| `test_dict_method` | `.dict()` returns correct dict |
+| `test_str_repr` | String representation includes class name and data |
+
+### TestCleaningStatus — DP 0 (Start/Stop/Return)
+| Test | Description |
+|------|-------------|
+| `test_cleaning` | Data `03` → `CLEANING` |
+| `test_stopped` | Data `01` → `STOPPED` |
+| `test_returning` | Data `02` → `RETURNING` |
+| `test_returning_to_dock` | Data `04` → `RETURNING_TO_DOCK` |
+| `test_setter` | Setting `CLEANING` → data becomes `03` |
+| `test_setter_stopped` | Setting `STOPPED` → data becomes `01` |
+| `test_no_data_returns_unknown` | No data → `UNKNOWN` |
+| `test_init_with_status_kwarg` | Create with `status=` keyword |
+| `test_str_repr` | String includes status name |
+
+### TestCleaningMode — DP 1 (Cleaning mode)
+| Test | Description |
+|------|-------------|
+| `test_floor_mode` | Data `00` → "Floor" |
+| `test_wall_mode` | Data `01` → "Wall" |
+| `test_all_modes_roundtrip` | All 7 modes survive set/get cycle |
+| `test_setter` | Setting "Turbo Floor" → data `05` |
+| `test_no_data_defaults_to_floor` | No data → defaults to "Floor" |
+
+### TestBattery — DP 50 (Battery level + charge state)
+| Test | Description |
+|------|-------------|
+| `test_charging_50` | `0132` → charging, 50% |
+| `test_charged_100` | `0264` → charged, 100% |
+| `test_unplugged_75` | `004b` → unplugged, 75% |
+| `test_no_data` | None data → 0%, not plugged in |
+
+### TestDock — DP 11 (Dock status)
+| Test | Description |
+|------|-------------|
+| `test_docked` | Data `00` → `DOCKED` |
+| `test_returning` | Data `01` → `RETURNING` |
+| `test_setter` | Setting `RETURNING` → data `01` |
+| `test_no_data` | No data → `GENERAL` |
+
+### TestSolarEnergyHarvested — DP 131
+| Test | Description |
+|------|-------------|
+| `test_energy_wh` | Little-endian `e8030000` → 1000 Wh |
+| `test_energy_kwh` | 1000 Wh → 1.0 kWh |
+| `test_no_data` | None → 0 Wh |
+
+### TestSolarDockBattery — DP 221
+| Test | Description |
+|------|-------------|
+| `test_battery_level` | `01480a` → 72% (byte 1) |
+| `test_no_data` | None → 0% |
+
+### TestSolarStatus — DP 222
+| Test | Description |
+|------|-------------|
+| `test_charging` | Data `01` → charging |
+| `test_not_charging` | Data `00` → not charging |
+
+### TestDockInfo — DP 214
+| Test | Description |
+|------|-------------|
+| `test_solar_dock` | Data `05` → Solar type, `is_solar_dock = True` |
+| `test_unknown_type` | Data `ff` → Unknown type |
+
+### TestDockConnectionStatus — DP 213
+| Test | Description |
+|------|-------------|
+| `test_docked` | Data `01` → docked |
+| `test_undocked` | Data `00` → undocked |
+
+### TestConnectionStatus — DP 212
+| Test | Description |
+|------|-------------|
+| `test_connected` | Data `01` → connected |
+| `test_disconnected` | Data `00` → disconnected |
+
+### TestDeviceStatus — DP 209
+| Test | Description |
+|------|-------------|
+| `test_status_value` | Data `03` → status_value = 3 |
+
+### TestSchedule — DP 79
+| Test | Description |
+|------|-------------|
+| `test_raw_schedule` | Returns raw hex string |
+
+### TestDPMapping — `wybot_dp_id` dict
+| Test | Description |
+|------|-------------|
+| `test_known_ids_return_correct_class` | DP 0→CleaningStatus, 1→CleaningMode, etc. |
+| `test_unknown_id_falls_back_to_generic` | Unknown ID → GenericDP |
+| `test_all_mapped_classes_can_instantiate` | Every mapped class can be created from a DP |
+
+---
+
+## test_models.py — API/MQTT Response Models (29 tests)
+
+### TestToSnakeCase — Helper function
+| Test | Description |
+|------|-------------|
+| `test_camel_case` | "deviceId" → "device_id" |
+| `test_pascal_case` | "DeviceName" → "device_name" |
+| `test_already_snake` | "device_id" unchanged |
+| `test_single_word` | "token" unchanged |
+| `test_consecutive_caps` | "deviceID" → "device_i_d" |
+| `test_empty_string` | "" → "" |
+
+### TestCommand — MQTT command envelope
+| Test | Description |
+|------|-------------|
+| `test_create_from_dict` | Parse JSON with cmd, ts, dp list |
+| `test_dp_list_types` | All dp items are DP instances |
+| `test_get_dps_as_keyed_dict` | Returns {id: TypedDP} using `wybot_dp_id` mapping |
+| `test_unknown_dp_id_defaults_to_generic` | Unknown DP ID → GenericDP |
+| `test_populate_by_name` | snake_case field names work directly |
+
+### TestLoginModels — Authentication
+| Test | Description |
+|------|-------------|
+| `test_login_metadata_from_api` | Parses camelCase (userId, regTime, etc.) |
+| `test_login_response_success` | Full response with nested metadata |
+| `test_login_response_no_metadata` | 401 response, metadata = None |
+
+### TestVersion — Firmware info
+| Test | Description |
+|------|-------------|
+| `test_from_api_alias` | `{"Firmware": "1.2.3"}` via alias |
+| `test_none_firmware` | Firmware can be None |
+
+### TestDevice — Robot device
+| Test | Description |
+|------|-------------|
+| `test_from_api` | All camelCase aliases (deviceId, bleName, etc.) |
+| `test_defaults` | online=False, dps={} |
+| `test_get_dp_returns_none_when_empty` | No DPs → None |
+| `test_get_dp_raises_for_non_generic` | Non-GenericDP class → TypeError |
+
+### TestDocker — Dock device
+| Test | Description |
+|------|-------------|
+| `test_from_api` | All aliases (dockerId, dockerType, etc.) |
+| `test_defaults` | online=False, dps={} |
+
+### TestVision — Vision module
+| Test | Description |
+|------|-------------|
+| `test_from_api` | Parses visionId alias, optional fields |
+
+### TestGroup — Device group (robot + dock + vision)
+| Test | Description |
+|------|-------------|
+| `test_from_api` | Full group with device, docker, vision |
+| `test_without_docker` | docker = None (standalone robot) |
+| `test_get_dp_searches_device_first` | Searches device DPs first |
+| `test_get_dp_searches_docker_fallback` | Falls back to docker DPs |
+
+### TestDevicesResponse — Full API response
+| Test | Description |
+|------|-------------|
+| `test_full_response` | Nested code/reason/message/metadata/groups |
+| `test_empty_groups` | Empty groups list |

--- a/blueprints/wybot_all_in_one.yaml
+++ b/blueprints/wybot_all_in_one.yaml
@@ -1,0 +1,209 @@
+blueprint:
+  name: "WyBot: Pool Robot Notifications & Schedule"
+  description: >
+    All-in-one blueprint for your WyBot pool robot. Enable the features you want:
+    get notified when cleaning is done, when the robot is fully charged, when
+    battery is low, and/or schedule daily automatic cleaning.
+  domain: automation
+  source_url: https://github.com/bassrock/hass-wybot
+  input:
+    vacuum_entity:
+      name: WyBot vacuum
+      description: The WyBot vacuum entity.
+      selector:
+        entity:
+          filter:
+            - integration: wybot
+              domain: vacuum
+
+    battery_sensor:
+      name: Robot battery sensor
+      description: The WyBot battery level sensor.
+      selector:
+        entity:
+          filter:
+            - integration: wybot
+              domain: sensor
+              device_class: battery
+
+    charging_sensor:
+      name: Robot charging sensor
+      description: The WyBot charging binary sensor.
+      selector:
+        entity:
+          filter:
+            - integration: wybot
+              domain: binary_sensor
+              device_class: battery_charging
+
+    notify_service:
+      name: Notification service
+      description: The notification service to use (e.g. notify.mobile_app_my_phone).
+      selector:
+        action: {}
+
+    # --- Feature toggles ---
+    enable_cleaning_done:
+      name: "🏊 Notify when cleaning is done"
+      description: Send a notification when the robot returns to the dock after cleaning.
+      default: true
+      selector:
+        boolean: {}
+
+    enable_fully_charged:
+      name: "🔋 Notify when fully charged"
+      description: Send a notification when the robot finishes charging.
+      default: true
+      selector:
+        boolean: {}
+
+    enable_low_battery:
+      name: "⚠️ Notify on low battery"
+      description: Send a notification when battery drops below a threshold.
+      default: false
+      selector:
+        boolean: {}
+
+    battery_threshold:
+      name: Low battery threshold (%)
+      description: Battery level to trigger low battery warning (only used if low battery notification is enabled).
+      default: 20
+      selector:
+        number:
+          min: 5
+          max: 50
+          step: 5
+          unit_of_measurement: "%"
+
+    enable_daily_schedule:
+      name: "📅 Daily cleaning schedule"
+      description: Automatically start cleaning at a set time each day.
+      default: false
+      selector:
+        boolean: {}
+
+    schedule_time:
+      name: Scheduled start time
+      description: Time to start daily cleaning (only used if schedule is enabled).
+      default: "10:00:00"
+      selector:
+        time: {}
+
+    min_battery_for_schedule:
+      name: Minimum battery for scheduled cleaning (%)
+      description: Only start scheduled cleaning if battery is above this level.
+      default: 50
+      selector:
+        number:
+          min: 10
+          max: 100
+          step: 10
+          unit_of_measurement: "%"
+
+    cleaning_mode:
+      name: Cleaning mode for schedule
+      description: Which cleaning mode to use for scheduled runs.
+      default: "Floor"
+      selector:
+        select:
+          options:
+            - "Floor"
+            - "Wall"
+            - "Wall Then Floor"
+            - "Advanced Full Pool"
+            - "Water Line"
+            - "Turbo Floor"
+            - "Eco Floor"
+
+trigger:
+  - platform: state
+    entity_id: !input vacuum_entity
+    from: "cleaning"
+    to: "docked"
+    id: cleaning_done
+
+  - platform: state
+    entity_id: !input vacuum_entity
+    from: "returning"
+    to: "docked"
+    id: cleaning_done
+
+  - platform: state
+    entity_id: !input charging_sensor
+    from: "on"
+    to: "off"
+    id: fully_charged
+
+  - platform: numeric_state
+    entity_id: !input battery_sensor
+    below: !input battery_threshold
+    id: low_battery
+
+  - platform: time
+    at: !input schedule_time
+    id: daily_schedule
+
+action:
+  - choose:
+      # --- Cleaning done ---
+      - conditions:
+          - condition: trigger
+            id: cleaning_done
+          - condition: !input enable_cleaning_done
+        sequence:
+          - action: !input notify_service
+            data:
+              title: "🏊 WyBot Cleaning Complete"
+              message: "Your pool robot has finished cleaning and is back in the dock."
+
+      # --- Fully charged ---
+      - conditions:
+          - condition: trigger
+            id: fully_charged
+          - condition: !input enable_fully_charged
+        sequence:
+          - action: !input notify_service
+            data:
+              title: "🔋 WyBot Fully Charged"
+              message: "Your WyBot pool robot is fully charged and ready to clean!"
+
+      # --- Low battery ---
+      - conditions:
+          - condition: trigger
+            id: low_battery
+          - condition: !input enable_low_battery
+        sequence:
+          - action: !input notify_service
+            data:
+              title: "⚠️ WyBot Battery Low"
+              message: >-
+                WyBot battery is at {{ states(trigger.entity_id) }}%.
+                Consider returning to dock.
+
+      # --- Daily schedule ---
+      - conditions:
+          - condition: trigger
+            id: daily_schedule
+          - condition: !input enable_daily_schedule
+          - condition: state
+            entity_id: !input vacuum_entity
+            state: "docked"
+          - condition: numeric_state
+            entity_id: !input battery_sensor
+            above: !input min_battery_for_schedule
+        sequence:
+          - action: vacuum.set_fan_speed
+            target:
+              entity_id: !input vacuum_entity
+            data:
+              fan_speed: !input cleaning_mode
+          - action: vacuum.start
+            target:
+              entity_id: !input vacuum_entity
+          - action: !input notify_service
+            data:
+              title: "🏊 WyBot Cleaning Started"
+              message: "Scheduled pool cleaning started."
+
+mode: queued
+max: 5

--- a/custom_components/wybot/manifest.json
+++ b/custom_components/wybot/manifest.json
@@ -6,15 +6,24 @@
       "local_name": "DS20-*"
     }
   ],
-  "codeowners": ["@bassrock"],
+  "codeowners": [
+    "@bassrock"
+  ],
   "config_flow": true,
-  "dependencies": ["bluetooth_adapters"],
+  "dependencies": [
+    "bluetooth_adapters"
+  ],
   "documentation": "https://github.com/bassrock/hass-wybot",
   "homekit": {},
   "iot_class": "cloud_push",
-  "requirements": ["pydantic", "paho-mqtt", "bleak"],
+  "requirements": [
+    "paho-mqtt",
+    "bleak"
+  ],
   "ssdp": [],
   "zeroconf": [],
   "version": "2.0.0",
-  "loggers": ["custom_components.wybot"]
+  "loggers": [
+    "custom_components.wybot"
+  ]
 }

--- a/custom_components/wybot/wybot_dp_models.py
+++ b/custom_components/wybot/wybot_dp_models.py
@@ -1,12 +1,12 @@
 from enum import Enum
 import logging
 
-from pydantic import v1 as pydantic_v1
+from pydantic import BaseModel
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DP(pydantic_v1.BaseModel):
+class DP(BaseModel):
     """Represents the response for a device command operation."""
 
     # Represents a data point for a command.
@@ -16,9 +16,9 @@ class DP(pydantic_v1.BaseModel):
     id: int
 
     # All our none if we are requesting data
-    type: int | None
-    len: int | None
-    data: str | None
+    type: int | None = None
+    len: int | None = None
+    data: str | None = None
 
 
 class GenericDP:
@@ -30,7 +30,7 @@ class GenericDP:
     # 5 = string that looks like hex
     type: int
     len: int
-    data: str | None
+    data: str | None = None
 
     def __init__(self, data: DP) -> None:
         self.id = data.id

--- a/custom_components/wybot/wybot_models.py
+++ b/custom_components/wybot/wybot_models.py
@@ -2,9 +2,11 @@
 
 from typing import TypeVar
 
-from pydantic import v1 as pydantic_v1
+from pydantic import BaseModel, ConfigDict, Field
 
 from .wybot_dp_models import DP, GenericDP, wybot_dp_id
+
+T = TypeVar("T", bound=GenericDP)
 
 
 def to_snake_case(string: str) -> str:
@@ -20,7 +22,7 @@ def to_snake_case(string: str) -> str:
     return "".join(["_" + i.lower() if i.isupper() else i for i in string]).lstrip("_")
 
 
-class Command(pydantic_v1.BaseModel):
+class Command(BaseModel):
     """Represents a command to be sent or received from a device."""
 
     # 4 - Send Write Command
@@ -34,33 +36,31 @@ class Command(pydantic_v1.BaseModel):
         """Return the DP list as a keyed dictionary."""
         return {str(dp.id): wybot_dp_id.get(dp.id, GenericDP)(dp) for dp in self.dp}
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class LoginMetadata(pydantic_v1.BaseModel):
+class LoginMetadata(BaseModel):
     """Represents the metadata for a user."""
 
-    user_id: str = pydantic_v1.Field(alias="userId")
+    user_id: str = Field(alias="userId")
     token: str
     username: str
     name: str
     avatar: str
     groupid: int
-    reg_time: int = pydantic_v1.Field(alias="regTime")
-    last_login_time: int = pydantic_v1.Field(alias="lastLoginTime")
+    reg_time: int = Field(alias="regTime")
+    last_login_time: int = Field(alias="lastLoginTime")
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class LoginResponse(pydantic_v1.BaseModel):
+class LoginResponse(BaseModel):
     """Represents the response for a login operation."""
 
     code: int
@@ -69,34 +69,31 @@ class LoginResponse(pydantic_v1.BaseModel):
     metadata: LoginMetadata | None = None
 
 
-class Version(pydantic_v1.BaseModel):
+class Version(BaseModel):
     """Represents the firmware version information for a device."""
 
-    firmware: str | None = pydantic_v1.Field(alias="Firmware")
+    firmware: str | None = Field(default=None, alias="Firmware")
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class Device(pydantic_v1.BaseModel):
+class Device(BaseModel):
     """Represents a device's information including identifiers, type, and version."""
 
-    device_id: str = pydantic_v1.Field(alias="deviceId")
-    device_name: str = pydantic_v1.Field(alias="deviceName")
-    device_type: str = pydantic_v1.Field(alias="deviceType")
-    ble_name: str = pydantic_v1.Field(alias="bleName")
+    device_id: str = Field(alias="deviceId")
+    device_name: str = Field(alias="deviceName")
+    device_type: str = Field(alias="deviceType")
+    ble_name: str = Field(alias="bleName")
     version: Version | None = None
-    pool_id: str | None = pydantic_v1.Field(alias="poolId")
-    auto_update: str = pydantic_v1.Field(alias="autoUpdate")
+    pool_id: str | None = Field(default=None, alias="poolId")
+    auto_update: str = Field(alias="autoUpdate")
 
-    "Extra added fields"
+    # Extra added fields
     online: bool = False
     dps: dict[str, DP] = {}
-
-    T = TypeVar("T", bound=GenericDP)
 
     def get_dp(self, cls: type[T]) -> T | None:
         """Get the specified DP from the device.
@@ -117,37 +114,33 @@ class Device(pydantic_v1.BaseModel):
                 return dp
         return None
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
 
-
-class Docker(pydantic_v1.BaseModel):
+class Docker(BaseModel):
     """Represents a Docker container's information including identifiers, status, and schedule."""
 
-    docker_id: str = pydantic_v1.Field(alias="dockerId")
-    docker_type: str = pydantic_v1.Field(alias="dockerType")
-    ble_name: str = pydantic_v1.Field(alias="bleName")
-    device_status: str = pydantic_v1.Field(alias="deviceStatus")
-    docker_status: str = pydantic_v1.Field(alias="dockerStatus")
-    schedule: str | None = pydantic_v1.Field(alias="schedule")
+    docker_id: str = Field(alias="dockerId")
+    docker_type: str = Field(alias="dockerType")
+    ble_name: str = Field(alias="bleName")
+    device_status: str = Field(alias="deviceStatus")
+    docker_status: str = Field(alias="dockerStatus")
+    schedule: str | None = Field(default=None, alias="schedule")
     version: Version | None = None
 
-    "Extra added fields"
+    # Extra added fields
     online: bool = False
     dps: dict[str, DP] = {}
 
-    class Config:
-        """Represents the configuration options for the class."""
-
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-
-    T = TypeVar("T", bound=GenericDP)
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
     def get_dp(self, cls: type[T]) -> T | None:
         """Get the specified DP from the device.
@@ -169,41 +162,37 @@ class Docker(pydantic_v1.BaseModel):
         return None
 
 
-class Vision(pydantic_v1.BaseModel):
+class Vision(BaseModel):
     """Represents vision-related information including privacy settings, logs, and media."""
 
-    vision_id: str | None = pydantic_v1.Field(alias="visionId")
+    vision_id: str | None = Field(default=None, alias="visionId")
     privacy: bool
-    log: str | None
-    video: str | None
-    picture: str | None
+    log: str | None = None
+    video: str | None = None
+    picture: str | None = None
     policy: bool
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class Group(pydantic_v1.BaseModel):
+class Group(BaseModel):
     """Represents a group containing Docker, Device, and Vision information."""
 
-    docker: Docker | None
+    docker: Docker | None = None
     device: Device
     vision: Vision
     name: str
     id: str
-    auto_update: str = pydantic_v1.Field(alias="autoUpdate")
+    auto_update: str = Field(alias="autoUpdate")
 
-    class Config:
-        """Represents the configuration options for the class."""
-
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-
-    T = TypeVar("T", bound=GenericDP)
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
     def get_dp(self, cls: type[T]) -> T | None:
         if not issubclass(cls, GenericDP):
@@ -220,19 +209,18 @@ class Group(pydantic_v1.BaseModel):
         return None
 
 
-class DeviceMetadata(pydantic_v1.BaseModel):
+class DeviceMetadata(BaseModel):
     """Represents metadata containing a list of groups."""
 
     groups: list[Group]
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class DevicesResponse(pydantic_v1.BaseModel):
+class DevicesResponse(BaseModel):
     """Represents the API response for devices containing status code, reason, message, and metadata."""
 
     code: int
@@ -240,8 +228,7 @@ class DevicesResponse(pydantic_v1.BaseModel):
     message: str
     metadata: DeviceMetadata
 
-    class Config:
-        """Represents the configuration options for the class."""
-
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )

--- a/custom_components/wybot/wybot_models.py
+++ b/custom_components/wybot/wybot_models.py
@@ -30,7 +30,7 @@ class Command(BaseModel):
     # 9 - Data Request
     cmd: int
     dp: list[DP]
-    ts: int
+    ts: float
 
     def get_dps_as_keyed_dict(self) -> dict[str, GenericDP]:
         """Return the DP list as a keyed dictionary."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,155 @@
+"""Fixtures and helpers for hass-wybot tests.
+
+Uses sys.path manipulation to import model files directly without
+triggering the HA-dependent __init__.py.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Add the custom_components/wybot directory to sys.path so we can import
+# the model modules DIRECTLY (not via the packages that need HA)
+_WYBOT_DIR = Path(__file__).parent.parent / "custom_components" / "wybot"
+
+# We need to prevent the __init__.py from being loaded when we import
+# submodules. We do this by registering mock parent packages.
+# HA core
+sys.modules.setdefault("homeassistant", MagicMock())
+sys.modules.setdefault("homeassistant.core", MagicMock())
+sys.modules.setdefault("homeassistant.config_entries", MagicMock())
+sys.modules.setdefault("homeassistant.const", MagicMock())
+sys.modules.setdefault("homeassistant.helpers", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.update_coordinator", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.config_validation", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.device_registry", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.entity_platform", MagicMock())
+sys.modules.setdefault("homeassistant.exceptions", MagicMock())
+sys.modules.setdefault("homeassistant.components.bluetooth", MagicMock())
+sys.modules.setdefault("homeassistant.components.vacuum", MagicMock())
+sys.modules.setdefault("homeassistant.components.sensor", MagicMock())
+sys.modules.setdefault("homeassistant.components.binary_sensor", MagicMock())
+sys.modules.setdefault("homeassistant.components.button", MagicMock())
+sys.modules.setdefault("homeassistant.util", MagicMock())
+sys.modules.setdefault("homeassistant.util.dt", MagicMock())
+
+# voluptuous
+sys.modules.setdefault("voluptuous", MagicMock())
+
+# BLE libraries
+sys.modules.setdefault("bleak", MagicMock())
+sys.modules.setdefault("bleak.backends", MagicMock())
+sys.modules.setdefault("bleak.backends.device", MagicMock())
+sys.modules.setdefault("bleak_retry_connector", MagicMock())
+
+# MQTT library
+sys.modules.setdefault("paho", MagicMock())
+sys.modules.setdefault("paho.mqtt", MagicMock())
+sys.modules.setdefault("paho.mqtt.client", MagicMock())
+
+# HTTP library
+sys.modules.setdefault("requests", MagicMock())
+sys.modules.setdefault("requests.adapters", MagicMock())
+sys.modules.setdefault("urllib3", MagicMock())
+sys.modules.setdefault("urllib3.util", MagicMock())
+sys.modules.setdefault("urllib3.util.retry", MagicMock())
+
+# Now ensure the wybot package directory is importable
+sys.path.insert(0, str(_WYBOT_DIR.parent.parent))
+
+
+@pytest.fixture
+def sample_dp_data():
+    """Return sample DP data dicts for testing."""
+    return {
+        "cleaning_status_cleaning": {"id": 0, "type": 4, "len": 1, "data": "03"},
+        "cleaning_status_stopped": {"id": 0, "type": 4, "len": 1, "data": "01"},
+        "cleaning_status_returning": {"id": 0, "type": 4, "len": 1, "data": "02"},
+        "cleaning_status_returning_dock": {"id": 0, "type": 4, "len": 1, "data": "04"},
+        "cleaning_mode_floor": {"id": 1, "type": 4, "len": 1, "data": "00"},
+        "cleaning_mode_wall": {"id": 1, "type": 4, "len": 1, "data": "01"},
+        "battery_charging_50": {"id": 50, "type": 0, "len": 2, "data": "0132"},
+        "battery_charged_100": {"id": 50, "type": 0, "len": 2, "data": "0264"},
+        "battery_unplugged_75": {"id": 50, "type": 0, "len": 2, "data": "004b"},
+        "dock_docked": {"id": 11, "type": 4, "len": 1, "data": "00"},
+        "dock_returning": {"id": 11, "type": 4, "len": 1, "data": "01"},
+        "solar_energy": {"id": 131, "type": 2, "len": 4, "data": "e8030000"},
+        "solar_dock_battery": {"id": 221, "type": 0, "len": 3, "data": "01480a"},
+        "solar_status_charging": {"id": 222, "type": 0, "len": 1, "data": "01"},
+        "solar_status_not_charging": {"id": 222, "type": 0, "len": 1, "data": "00"},
+        "dock_info_solar": {"id": 214, "type": 4, "len": 1, "data": "05"},
+        "dock_connection_docked": {"id": 213, "type": 4, "len": 1, "data": "01"},
+        "dock_connection_undocked": {"id": 213, "type": 4, "len": 1, "data": "00"},
+        "query_only": {"id": 0},
+    }
+
+
+@pytest.fixture
+def sample_api_device():
+    """Return sample API response for a device."""
+    return {
+        "deviceId": "dev123",
+        "deviceName": "Pool Robot",
+        "deviceType": "S2 Pro",
+        "bleName": "CCBA97932A96",
+        "poolId": "pool1",
+        "autoUpdate": "1",
+        "version": {"Firmware": "1.2.3"},
+    }
+
+
+@pytest.fixture
+def sample_api_docker():
+    """Return sample API response for a docker/dock."""
+    return {
+        "dockerId": "dock456",
+        "dockerType": "DS20",
+        "bleName": "3C8427565A1A",
+        "deviceStatus": "online",
+        "dockerStatus": "active",
+        "schedule": None,
+        "version": {"Firmware": "2.0.0"},
+    }
+
+
+@pytest.fixture
+def sample_api_vision():
+    """Return sample API response for vision data."""
+    return {
+        "visionId": "vis789",
+        "privacy": False,
+        "log": None,
+        "video": None,
+        "picture": None,
+        "policy": True,
+    }
+
+
+@pytest.fixture
+def sample_api_group(sample_api_device, sample_api_docker, sample_api_vision):
+    """Return sample API response for a group."""
+    return {
+        "device": sample_api_device,
+        "docker": sample_api_docker,
+        "vision": sample_api_vision,
+        "name": "My Pool",
+        "id": "group1",
+        "autoUpdate": "1",
+    }
+
+
+@pytest.fixture
+def sample_command_data():
+    """Return sample MQTT command data."""
+    return {
+        "cmd": 5,
+        "ts": 1700000000,
+        "dp": [
+            {"id": 0, "type": 4, "len": 1, "data": "03"},
+            {"id": 1, "type": 4, "len": 1, "data": "00"},
+            {"id": 50, "type": 0, "len": 2, "data": "0132"},
+        ],
+    }

--- a/tests/test_dp_models.py
+++ b/tests/test_dp_models.py
@@ -1,0 +1,388 @@
+"""Tests for wybot_dp_models.py — Data Point models."""
+
+import pytest
+
+from custom_components.wybot.wybot_dp_models import (
+    DP,
+    Battery,
+    BatteryState,
+    CleaningMode,
+    CleaningStatus,
+    CleaningStatusMode,
+    ConnectionStatus,
+    Dock,
+    DockConnectionStatus,
+    DockInfo,
+    DockStatus,
+    DockType,
+    GenericDP,
+    Schedule,
+    SolarDockBattery,
+    SolarEnergyHarvested,
+    SolarStatus,
+    SolarStatusMode,
+    DeviceStatus,
+    wybot_dp_id,
+)
+
+
+# =============================================================================
+# DP BaseModel
+# =============================================================================
+
+
+class TestDP:
+    """Tests for the DP pydantic model."""
+
+    def test_create_full(self):
+        dp = DP(id=0, type=4, len=1, data="03")
+        assert dp.id == 0
+        assert dp.type == 4
+        assert dp.len == 1
+        assert dp.data == "03"
+
+    def test_create_query_only(self):
+        """Query DPs only have id, other fields should default to None."""
+        dp = DP(id=0)
+        assert dp.id == 0
+        assert dp.type is None
+        assert dp.len is None
+        assert dp.data is None
+
+    def test_create_from_dict(self):
+        dp = DP.model_validate({"id": 50, "type": 0, "len": 2, "data": "0132"})
+        assert dp.id == 50
+        assert dp.data == "0132"
+
+    def test_serialization(self):
+        dp = DP(id=1, type=4, len=1, data="00")
+        dumped = dp.model_dump()
+        assert dumped == {"id": 1, "type": 4, "len": 1, "data": "00"}
+
+
+# =============================================================================
+# GenericDP
+# =============================================================================
+
+
+class TestGenericDP:
+    """Tests for the GenericDP plain Python class."""
+
+    def test_init_from_dp(self):
+        dp = DP(id=99, type=5, len=2, data="ab")
+        generic = GenericDP(dp)
+        assert generic.id == 99
+        assert generic.type == 5
+        assert generic.len == 2
+        assert generic.data == "ab"
+
+    def test_dict_method(self):
+        dp = DP(id=0, type=4, len=1, data="03")
+        generic = GenericDP(dp)
+        result = generic.dict()
+        assert result == {"id": 0, "type": 4, "len": 1, "data": "03"}
+
+    def test_str_repr(self):
+        dp = DP(id=0, type=4, len=1, data="03")
+        generic = GenericDP(dp)
+        s = str(generic)
+        assert "GenericDP" in s
+        assert "03" in s
+
+
+# =============================================================================
+# CleaningStatus
+# =============================================================================
+
+
+class TestCleaningStatus:
+    """Tests for CleaningStatus DP."""
+
+    def test_cleaning(self, sample_dp_data):
+        dp = DP(**sample_dp_data["cleaning_status_cleaning"])
+        cs = CleaningStatus(dp)
+        assert cs.status == CleaningStatusMode.CLEANING
+
+    def test_stopped(self, sample_dp_data):
+        dp = DP(**sample_dp_data["cleaning_status_stopped"])
+        cs = CleaningStatus(dp)
+        assert cs.status == CleaningStatusMode.STOPPED
+
+    def test_returning(self, sample_dp_data):
+        dp = DP(**sample_dp_data["cleaning_status_returning"])
+        cs = CleaningStatus(dp)
+        assert cs.status == CleaningStatusMode.RETURNING
+
+    def test_returning_to_dock(self, sample_dp_data):
+        dp = DP(**sample_dp_data["cleaning_status_returning_dock"])
+        cs = CleaningStatus(dp)
+        assert cs.status == CleaningStatusMode.RETURNING_TO_DOCK
+
+    def test_setter(self):
+        cs = CleaningStatus()
+        cs.status = CleaningStatusMode.CLEANING
+        assert cs.data == "03"
+        assert cs.status == CleaningStatusMode.CLEANING
+
+    def test_setter_stopped(self):
+        cs = CleaningStatus()
+        cs.status = CleaningStatusMode.STOPPED
+        assert cs.data == "01"
+
+    def test_no_data_returns_unknown(self):
+        cs = CleaningStatus()
+        assert cs.status == CleaningStatusMode.UNKNOWN
+
+    def test_init_with_status_kwarg(self):
+        cs = CleaningStatus(status=CleaningStatusMode.CLEANING)
+        assert cs.status == CleaningStatusMode.CLEANING
+        assert cs.data == "03"
+
+    def test_str_repr(self):
+        cs = CleaningStatus(status=CleaningStatusMode.CLEANING)
+        assert "CleaningStatus" in str(cs)
+        assert "CLEANING" in str(cs)
+
+
+# =============================================================================
+# CleaningMode
+# =============================================================================
+
+
+class TestCleaningMode:
+    """Tests for CleaningMode DP."""
+
+    def test_floor_mode(self, sample_dp_data):
+        dp = DP(**sample_dp_data["cleaning_mode_floor"])
+        cm = CleaningMode(dp)
+        assert cm.cleaning_mode == "Floor"
+
+    def test_wall_mode(self, sample_dp_data):
+        dp = DP(**sample_dp_data["cleaning_mode_wall"])
+        cm = CleaningMode(dp)
+        assert cm.cleaning_mode == "Wall"
+
+    def test_all_modes_roundtrip(self):
+        for mode_name in CleaningMode.CLEANING_MODES:
+            cm = CleaningMode(mode=mode_name)
+            assert cm.cleaning_mode == mode_name
+
+    def test_setter(self):
+        cm = CleaningMode()
+        cm.cleaning_mode = "Turbo Floor"
+        assert cm.cleaning_mode == "Turbo Floor"
+        assert cm.data == "05"
+
+    def test_no_data_defaults_to_floor(self):
+        cm = CleaningMode()
+        assert cm.cleaning_mode == "Floor"
+
+
+# =============================================================================
+# Battery
+# =============================================================================
+
+
+class TestBattery:
+    """Tests for Battery DP."""
+
+    def test_charging_50(self, sample_dp_data):
+        dp = DP(**sample_dp_data["battery_charging_50"])
+        bat = Battery(dp)
+        assert bat.charge_state == BatteryState.CHARGING
+        assert bat.battery_level == 50  # 0x32 = 50
+
+    def test_charged_100(self, sample_dp_data):
+        dp = DP(**sample_dp_data["battery_charged_100"])
+        bat = Battery(dp)
+        assert bat.charge_state == BatteryState.CHARGED
+        assert bat.battery_level == 100  # 0x64 = 100
+
+    def test_unplugged_75(self, sample_dp_data):
+        dp = DP(**sample_dp_data["battery_unplugged_75"])
+        bat = Battery(dp)
+        assert bat.charge_state == BatteryState.NOT_PLUGGED_IN
+        assert bat.battery_level == 75  # 0x4b = 75
+
+    def test_no_data(self):
+        dp = DP(id=50, type=0, len=2, data=None)
+        bat = Battery(dp)
+        assert bat.battery_level == 0
+        assert bat.charge_state == BatteryState.NOT_PLUGGED_IN
+
+
+# =============================================================================
+# Dock
+# =============================================================================
+
+
+class TestDock:
+    """Tests for Dock DP."""
+
+    def test_docked(self, sample_dp_data):
+        dp = DP(**sample_dp_data["dock_docked"])
+        dock = Dock(dp)
+        assert dock.status == DockStatus.DOCKED
+
+    def test_returning(self, sample_dp_data):
+        dp = DP(**sample_dp_data["dock_returning"])
+        dock = Dock(dp)
+        assert dock.status == DockStatus.RETURNING
+
+    def test_setter(self):
+        dock = Dock(status=DockStatus.RETURNING)
+        assert dock.data == "01"
+
+    def test_no_data(self):
+        dock = Dock()
+        assert dock.status == DockStatus.GENERAL
+
+
+# =============================================================================
+# Solar DP classes
+# =============================================================================
+
+
+class TestSolarEnergyHarvested:
+    """Tests for SolarEnergyHarvested DP."""
+
+    def test_energy_wh(self, sample_dp_data):
+        dp = DP(**sample_dp_data["solar_energy"])
+        solar = SolarEnergyHarvested(dp)
+        # "e8030000" little-endian = 0x000003e8 = 1000 Wh
+        assert solar.energy_wh == 1000
+
+    def test_energy_kwh(self, sample_dp_data):
+        dp = DP(**sample_dp_data["solar_energy"])
+        solar = SolarEnergyHarvested(dp)
+        assert solar.energy_kwh == 1.0
+
+    def test_no_data(self):
+        dp = DP(id=131, type=2, len=4, data=None)
+        solar = SolarEnergyHarvested(dp)
+        assert solar.energy_wh == 0
+
+
+class TestSolarDockBattery:
+    """Tests for SolarDockBattery DP."""
+
+    def test_battery_level(self, sample_dp_data):
+        dp = DP(**sample_dp_data["solar_dock_battery"])
+        bat = SolarDockBattery(dp)
+        # "01480a" -> byte 1 (chars 2-3) = 0x48 = 72%
+        assert bat.battery_level == 72
+
+    def test_no_data(self):
+        dp = DP(id=221, type=0, len=3, data=None)
+        bat = SolarDockBattery(dp)
+        assert bat.battery_level == 0
+
+
+class TestSolarStatus:
+    """Tests for SolarStatus DP."""
+
+    def test_charging(self, sample_dp_data):
+        dp = DP(**sample_dp_data["solar_status_charging"])
+        ss = SolarStatus(dp)
+        assert ss.is_charging is True
+        assert ss.status == SolarStatusMode.CHARGING
+
+    def test_not_charging(self, sample_dp_data):
+        dp = DP(**sample_dp_data["solar_status_not_charging"])
+        ss = SolarStatus(dp)
+        assert ss.is_charging is False
+        assert ss.status == SolarStatusMode.NOT_CHARGING
+
+
+class TestDockInfo:
+    """Tests for DockInfo DP."""
+
+    def test_solar_dock(self, sample_dp_data):
+        dp = DP(**sample_dp_data["dock_info_solar"])
+        di = DockInfo(dp)
+        assert di.dock_type == DockType.SOLAR
+        assert di.is_solar_dock is True
+
+    def test_unknown_type(self):
+        dp = DP(id=214, type=4, len=1, data="ff")
+        di = DockInfo(dp)
+        assert di.dock_type == DockType.UNKNOWN
+        assert di.is_solar_dock is False
+
+
+class TestDockConnectionStatus:
+    """Tests for DockConnectionStatus DP."""
+
+    def test_docked(self, sample_dp_data):
+        dp = DP(**sample_dp_data["dock_connection_docked"])
+        dcs = DockConnectionStatus(dp)
+        assert dcs.is_docked is True
+
+    def test_undocked(self, sample_dp_data):
+        dp = DP(**sample_dp_data["dock_connection_undocked"])
+        dcs = DockConnectionStatus(dp)
+        assert dcs.is_docked is False
+
+
+class TestConnectionStatus:
+    """Tests for ConnectionStatus DP."""
+
+    def test_connected(self):
+        dp = DP(id=212, type=4, len=1, data="01")
+        cs = ConnectionStatus(dp)
+        assert cs.is_connected is True
+
+    def test_disconnected(self):
+        dp = DP(id=212, type=4, len=1, data="00")
+        cs = ConnectionStatus(dp)
+        assert cs.is_connected is False
+
+
+class TestDeviceStatus:
+    """Tests for DeviceStatus DP."""
+
+    def test_status_value(self):
+        dp = DP(id=209, type=4, len=1, data="03")
+        ds = DeviceStatus(dp)
+        assert ds.status_value == 3
+
+
+class TestSchedule:
+    """Tests for Schedule DP."""
+
+    def test_raw_schedule(self):
+        dp = DP(id=79, type=2, len=12, data="abcdef123456abcdef123456")
+        sc = Schedule(dp)
+        assert sc.raw_schedule == "abcdef123456abcdef123456"
+
+
+# =============================================================================
+# wybot_dp_id mapping
+# =============================================================================
+
+
+class TestDPMapping:
+    """Tests for the wybot_dp_id mapping dict."""
+
+    def test_known_ids_return_correct_class(self):
+        assert wybot_dp_id[0] is CleaningStatus
+        assert wybot_dp_id[1] is CleaningMode
+        assert wybot_dp_id[11] is Dock
+        assert wybot_dp_id[50] is Battery
+        assert wybot_dp_id[79] is Schedule
+        assert wybot_dp_id[131] is SolarEnergyHarvested
+        assert wybot_dp_id[214] is DockInfo
+        assert wybot_dp_id[221] is SolarDockBattery
+        assert wybot_dp_id[222] is SolarStatus
+
+    def test_unknown_id_falls_back_to_generic(self):
+        """wybot_dp_id.get(unknown_id, GenericDP) should return GenericDP."""
+        result = wybot_dp_id.get(9999, GenericDP)
+        assert result is GenericDP
+
+    def test_all_mapped_classes_can_instantiate(self, sample_dp_data):
+        """Verify every mapped DP class can be instantiated from a DP."""
+        for dp_id, dp_class in wybot_dp_id.items():
+            dp = DP(id=dp_id, type=4, len=1, data="01")
+            instance = dp_class(dp)
+            assert instance.id == dp_id

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,319 @@
+"""Tests for wybot_models.py — HTTP/MQTT response models."""
+
+import pytest
+
+from custom_components.wybot.wybot_dp_models import (
+    DP,
+    Battery,
+    CleaningMode,
+    CleaningStatus,
+    GenericDP,
+)
+from custom_components.wybot.wybot_models import (
+    Command,
+    Device,
+    DeviceMetadata,
+    DevicesResponse,
+    Docker,
+    Group,
+    LoginMetadata,
+    LoginResponse,
+    Version,
+    Vision,
+    to_snake_case,
+)
+
+
+# =============================================================================
+# to_snake_case helper
+# =============================================================================
+
+
+class TestToSnakeCase:
+    """Tests for the to_snake_case helper function."""
+
+    def test_camel_case(self):
+        assert to_snake_case("deviceId") == "device_id"
+
+    def test_pascal_case(self):
+        assert to_snake_case("DeviceName") == "device_name"
+
+    def test_already_snake(self):
+        assert to_snake_case("device_id") == "device_id"
+
+    def test_single_word(self):
+        assert to_snake_case("token") == "token"
+
+    def test_consecutive_caps(self):
+        assert to_snake_case("deviceID") == "device_i_d"
+
+    def test_empty_string(self):
+        assert to_snake_case("") == ""
+
+
+# =============================================================================
+# Command
+# =============================================================================
+
+
+class TestCommand:
+    """Tests for the Command model."""
+
+    def test_create_from_dict(self, sample_command_data):
+        cmd = Command(**sample_command_data)
+        assert cmd.cmd == 5
+        assert cmd.ts == 1700000000
+        assert len(cmd.dp) == 3
+
+    def test_dp_list_types(self, sample_command_data):
+        cmd = Command(**sample_command_data)
+        for dp in cmd.dp:
+            assert isinstance(dp, DP)
+
+    def test_get_dps_as_keyed_dict(self, sample_command_data):
+        cmd = Command(**sample_command_data)
+        dp_dict = cmd.get_dps_as_keyed_dict()
+        assert "0" in dp_dict
+        assert "1" in dp_dict
+        assert "50" in dp_dict
+        assert isinstance(dp_dict["0"], CleaningStatus)
+        assert isinstance(dp_dict["1"], CleaningMode)
+        assert isinstance(dp_dict["50"], Battery)
+
+    def test_unknown_dp_id_defaults_to_generic(self):
+        cmd = Command(
+            cmd=5,
+            ts=0,
+            dp=[DP(id=9999, type=4, len=1, data="01")],
+        )
+        dp_dict = cmd.get_dps_as_keyed_dict()
+        assert isinstance(dp_dict["9999"], GenericDP)
+
+    def test_populate_by_name(self):
+        """Test that snake_case field names work directly."""
+        cmd = Command(cmd=4, dp=[], ts=100)
+        assert cmd.cmd == 4
+
+
+# =============================================================================
+# LoginMetadata / LoginResponse
+# =============================================================================
+
+
+class TestLoginModels:
+    """Tests for login-related models."""
+
+    def test_login_metadata_from_api(self):
+        data = {
+            "userId": "user1",
+            "token": "abc123",
+            "username": "test@test.com",
+            "name": "Test User",
+            "avatar": "https://example.com/avatar.png",
+            "groupid": 1,
+            "regTime": 1600000000,
+            "lastLoginTime": 1700000000,
+        }
+        meta = LoginMetadata(**data)
+        assert meta.user_id == "user1"
+        assert meta.token == "abc123"
+        assert meta.reg_time == 1600000000
+        assert meta.last_login_time == 1700000000
+
+    def test_login_response_success(self):
+        data = {
+            "code": 200,
+            "reason": "OK",
+            "message": "Success",
+            "metadata": {
+                "userId": "user1",
+                "token": "abc123",
+                "username": "test@test.com",
+                "name": "Test",
+                "avatar": "",
+                "groupid": 1,
+                "regTime": 0,
+                "lastLoginTime": 0,
+            },
+        }
+        resp = LoginResponse(**data)
+        assert resp.code == 200
+        assert resp.metadata is not None
+        assert resp.metadata.token == "abc123"
+
+    def test_login_response_no_metadata(self):
+        data = {
+            "code": 401,
+            "reason": "Unauthorized",
+            "message": "Invalid credentials",
+        }
+        resp = LoginResponse(**data)
+        assert resp.code == 401
+        assert resp.metadata is None
+
+
+# =============================================================================
+# Version
+# =============================================================================
+
+
+class TestVersion:
+    """Tests for the Version model."""
+
+    def test_from_api_alias(self):
+        v = Version(**{"Firmware": "1.2.3"})
+        assert v.firmware == "1.2.3"
+
+    def test_none_firmware(self):
+        v = Version(**{"Firmware": None})
+        assert v.firmware is None
+
+
+# =============================================================================
+# Device
+# =============================================================================
+
+
+class TestDevice:
+    """Tests for the Device model."""
+
+    def test_from_api(self, sample_api_device):
+        dev = Device(**sample_api_device)
+        assert dev.device_id == "dev123"
+        assert dev.device_name == "Pool Robot"
+        assert dev.device_type == "S2 Pro"
+        assert dev.ble_name == "CCBA97932A96"
+        assert dev.pool_id == "pool1"
+        assert dev.auto_update == "1"
+        assert dev.version is not None
+        assert dev.version.firmware == "1.2.3"
+
+    def test_defaults(self, sample_api_device):
+        dev = Device(**sample_api_device)
+        assert dev.online is False
+        assert dev.dps == {}
+
+    def test_get_dp_returns_none_when_empty(self, sample_api_device):
+        dev = Device(**sample_api_device)
+        assert dev.get_dp(CleaningStatus) is None
+
+    def test_get_dp_raises_for_non_generic(self, sample_api_device):
+        dev = Device(**sample_api_device)
+        with pytest.raises(TypeError):
+            dev.get_dp(str)  # type: ignore
+
+
+# =============================================================================
+# Docker
+# =============================================================================
+
+
+class TestDocker:
+    """Tests for the Docker model."""
+
+    def test_from_api(self, sample_api_docker):
+        dock = Docker(**sample_api_docker)
+        assert dock.docker_id == "dock456"
+        assert dock.docker_type == "DS20"
+        assert dock.ble_name == "3C8427565A1A"
+        assert dock.device_status == "online"
+        assert dock.docker_status == "active"
+
+    def test_defaults(self, sample_api_docker):
+        dock = Docker(**sample_api_docker)
+        assert dock.online is False
+        assert dock.dps == {}
+
+
+# =============================================================================
+# Vision
+# =============================================================================
+
+
+class TestVision:
+    """Tests for the Vision model."""
+
+    def test_from_api(self, sample_api_vision):
+        vis = Vision(**sample_api_vision)
+        assert vis.vision_id == "vis789"
+        assert vis.privacy is False
+        assert vis.policy is True
+        assert vis.log is None
+
+
+# =============================================================================
+# Group
+# =============================================================================
+
+
+class TestGroup:
+    """Tests for the Group model."""
+
+    def test_from_api(self, sample_api_group):
+        group = Group(**sample_api_group)
+        assert group.name == "My Pool"
+        assert group.id == "group1"
+        assert group.device is not None
+        assert group.docker is not None
+        assert group.vision is not None
+
+    def test_without_docker(self, sample_api_device, sample_api_vision):
+        data = {
+            "device": sample_api_device,
+            "docker": None,
+            "vision": sample_api_vision,
+            "name": "Solo Pool",
+            "id": "group2",
+            "autoUpdate": "0",
+        }
+        group = Group(**data)
+        assert group.docker is None
+        assert group.device.device_id == "dev123"
+
+    def test_get_dp_searches_device_first(self, sample_api_group):
+        group = Group(**sample_api_group)
+        # No DPs loaded, should return None
+        assert group.get_dp(CleaningStatus) is None
+
+    def test_get_dp_searches_docker_fallback(self, sample_api_group):
+        group = Group(**sample_api_group)
+        # Add a DP to docker
+        dp = DP(id=0, type=4, len=1, data="03")
+        cs = CleaningStatus(dp)
+        group.docker.dps = {"0": cs}
+        # Should find it via docker fallback
+        found = group.get_dp(CleaningStatus)
+        assert found is not None
+        assert isinstance(found, CleaningStatus)
+
+
+# =============================================================================
+# DevicesResponse (full API response)
+# =============================================================================
+
+
+class TestDevicesResponse:
+    """Tests for the full API response model."""
+
+    def test_full_response(self, sample_api_group):
+        data = {
+            "code": 200,
+            "reason": "OK",
+            "message": "Success",
+            "metadata": {"groups": [sample_api_group]},
+        }
+        resp = DevicesResponse(**data)
+        assert resp.code == 200
+        assert len(resp.metadata.groups) == 1
+        assert resp.metadata.groups[0].name == "My Pool"
+        assert resp.metadata.groups[0].device.device_id == "dev123"
+
+    def test_empty_groups(self):
+        data = {
+            "code": 200,
+            "reason": "OK",
+            "message": "No devices",
+            "metadata": {"groups": []},
+        }
+        resp = DevicesResponse(**data)
+        assert len(resp.metadata.groups) == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,7 +62,7 @@ class TestCommand:
     def test_create_from_dict(self, sample_command_data):
         cmd = Command(**sample_command_data)
         assert cmd.cmd == 5
-        assert cmd.ts == 1700000000
+        assert cmd.ts == 1700000000.0
         assert len(cmd.dp) == 3
 
     def test_dp_list_types(self, sample_command_data):


### PR DESCRIPTION
# Migrate to pydantic v2, add tests, CI, and improved docs
## Problem
The integration uses `from pydantic import v1 as pydantic_v1` — the v1 compatibility shim. This is deprecated on Python 3.13 (HA 2025.2+) and **fully removed in Python 3.14**, causing `ModuleNotFoundError` at startup.
## Changes
### Pydantic v2 migration
- `wybot_dp_models.py` / `wybot_models.py` — All 10 models migrated to native pydantic v2 (`BaseModel`, `ConfigDict`, `Field`, `populate_by_name`). `TypeVar` moved to module level (v2 treats class-level TypeVars as model fields).
- `manifest.json` — Removed `pydantic` from requirements (bundled by HA Core)
### Bug fix
- `Command.ts` changed from `int` to `float` — MQTT broker sends fractional timestamps (e.g. `1772861625.645`) that pydantic v2 correctly rejects as invalid integers
### Test suite (new — 76 tests)
- `tests/conftest.py` — Fixtures with mocked HA/BLE/MQTT dependencies
- `tests/test_dp_models.py` — 47 tests covering all DP classes, hex parsing, enum conversion, and the `wybot_dp_id` mapping
- `tests/test_models.py` — 29 tests covering all response models, camelCase alias deserialization, nested models, and `get_dps_as_keyed_dict()`
### CI (new)
- `.github/workflows/tests.yml` — Runs tests on push/PR against Python 3.13 and 3.14
### Documentation (improved)
- `README.md` — Added features list, entity documentation, configuration guide, architecture overview, and tested devices table (S2 Pro, C1)
- `DEVELOPER.md` (new) — Developer setup and test instructions
- `TESTS.md` (new) — Detailed reference of all 76 tests
## No breaking changes
All models accept the same camelCase JSON input and produce identical output. The `GenericDP.dict()` method used by the coordinator is a plain Python method, not pydantic's `.dict()`, and is unaffected.
## Tested with
- ✅ Python 3.14.0 + pydantic 2.12.5 — 76/76 tests passing