### PR TITLE
fix: migrate from pydantic v1 to native v2 for HA 2026.1+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+extracts/

--- a/custom_components/wybot/__init__.py
+++ b/custom_components/wybot/__init__.py
@@ -2,91 +2,433 @@
 
 import asyncio
 import logging
+from typing import Any
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryAuthFailed, ConfigEntryNotReady
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
+from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN
-from .wybot_http_client import WyBotHTTPClient
-from .wybot_mqtt_client import WyBotMQTTClient
+from .const import CONF_WIFI_PASSWORD, CONF_WIFI_SSID, DOMAIN
+from .wybot_ble_client import WyBotBLEClient
 from .wybot_coordinator import WyBotCoordinator
+from .wybot_http_client import WyBotHTTPClient
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.VACUUM]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR, Platform.VACUUM]
 _LOGGER = logging.getLogger(__name__)
 
-# Retry configuration for initial setup
-MAX_SETUP_RETRIES = 3
-SETUP_RETRY_DELAY = 2.0
+# Service names
+SERVICE_BLE_SCAN = "ble_scan"
+SERVICE_BLE_DISCOVER = "ble_discover"
+SERVICE_BLE_WAKE = "ble_wake"
+SERVICE_BLE_QUERY = "ble_query"
+
+# Service schema
+SERVICE_BLE_ADDRESS_SCHEMA = vol.Schema({
+    vol.Required("ble_address"): cv.string,
+})
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up WyBot from a config entry."""
+
     hass.data.setdefault(DOMAIN, {})
     wybot_http_client = WyBotHTTPClient(
         entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
     )
 
-    # Retry authentication with exponential backoff
-    delay = SETUP_RETRY_DELAY
-    last_error = None
-    for attempt in range(MAX_SETUP_RETRIES):
-        try:
-            authed = await hass.async_add_executor_job(wybot_http_client.authenticate)
-            if authed:
-                break
-            else:
-                _LOGGER.warning("Authentication failed (attempt %d/%d)",
-                              attempt + 1, MAX_SETUP_RETRIES)
-                if attempt < MAX_SETUP_RETRIES - 1:
-                    await asyncio.sleep(delay)
-                    delay *= 2
-                else:
-                    raise ConfigEntryAuthFailed("Invalid username or password")
-        except ConfigEntryAuthFailed:
-            # Re-raise auth failures immediately
-            raise
-        except Exception as err:
-            last_error = err
-            _LOGGER.warning("Authentication error (attempt %d/%d): %s",
-                          attempt + 1, MAX_SETUP_RETRIES, err)
-            if attempt < MAX_SETUP_RETRIES - 1:
-                await asyncio.sleep(delay)
-                delay *= 2
-            else:
-                raise ConfigEntryNotReady(
-                    f"Failed to authenticate after {MAX_SETUP_RETRIES} attempts"
-                ) from err
+    authed = await hass.async_add_executor_job(wybot_http_client.authenticate)
+    if not authed:
+        return False
 
-    coordinator = WyBotCoordinator(hass, wybot_http_client=wybot_http_client)
+    # Create coordinator with config entry for WiFi credentials
+    coordinator = WyBotCoordinator(
+        hass, wybot_http_client=wybot_http_client, config_entry=entry
+    )
+
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except ConfigEntryAuthFailed:
-        # Re-raise auth failures
-        raise
-    except Exception as err:
-        raise ConfigEntryNotReady(
-            "Failed to connect to WyBot API during setup"
-        ) from err
+    await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    async def stop_mqtt(event):
-        """Stop MQTT client on Home Assistant stop."""
+    # Register cleanup using entry.async_on_unload pattern
+    async def _async_stop_coordinator() -> None:
+        """Stop coordinator resources on unload."""
         await coordinator.async_stop()
 
-    hass.bus.async_listen_once("homeassistant_stop", stop_mqtt)
+    entry.async_on_unload(_async_stop_coordinator)
+
+    # Listen for options updates to refresh WiFi credentials
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     return True
 
 
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update.
+
+    Called when config entry options are updated via the UI.
+    Updates stored WiFi credentials for manual provisioning via diagnostic button.
+    """
+    coordinator: WyBotCoordinator = hass.data[DOMAIN][entry.entry_id]
+    # Update WiFi credentials directly (for manual provisioning only)
+    coordinator._wifi_ssid = entry.data.get(CONF_WIFI_SSID)
+    coordinator._wifi_password = entry.data.get(CONF_WIFI_PASSWORD)
+    if coordinator._wifi_ssid:
+        _LOGGER.debug(
+            "WiFi credentials updated for SSID: %s", coordinator._wifi_ssid
+        )
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    await coordinator.async_stop()
+    # Note: coordinator.async_stop() is called via entry.async_on_unload
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the WyBot component and register services."""
+    hass.data.setdefault(DOMAIN, {})
+
+    async def handle_ble_scan(call: ServiceCall) -> ServiceResponse:
+        """Handle BLE scan service call."""
+        from homeassistant.components.bluetooth import async_discovered_service_info
+
+        _LOGGER.info("=== WyBot BLE Scan ===")
+
+        try:
+            service_infos = async_discovered_service_info(hass, connectable=True)
+            devices_found = []
+            wybot_devices = []
+
+            for info in service_infos:
+                device = info.device
+                device_info = {
+                    "name": device.name or "Unknown",
+                    "address": device.address,
+                    "rssi": info.rssi if hasattr(info, "rssi") else None,
+                }
+                devices_found.append(device_info)
+
+                # Check if it's a WyBot device
+                if device.name and len(device.name) == 12:
+                    if all(c in "0123456789ABCDEFabcdef" for c in device.name):
+                        wybot_devices.append(device_info)
+                        _LOGGER.info(
+                            "  [WYBOT] %s at %s (RSSI: %s)",
+                            device.name,
+                            device.address,
+                            device_info["rssi"],
+                        )
+
+            _LOGGER.info("Total BLE devices: %d, WyBot devices: %d", len(devices_found), len(wybot_devices))
+
+            return {
+                "total_devices": len(devices_found),
+                "wybot_devices": wybot_devices,
+                "all_devices": devices_found[:20],  # Limit to avoid large response
+            }
+
+        except Exception as err:
+            _LOGGER.error("BLE scan failed: %s", err)
+            return {"error": str(err)}
+
+    async def handle_ble_discover(call: ServiceCall) -> ServiceResponse:
+        """Handle BLE discover services call."""
+        ble_address = call.data["ble_address"]
+        ble_client = WyBotBLEClient(hass)
+
+        _LOGGER.info("=== WyBot BLE Service Discovery for %s ===", ble_address)
+
+        # Scan to find the device first
+        device = await ble_client.scan_for_device(ble_address)
+
+        if not device:
+            _LOGGER.warning("Device %s not found in scan", ble_address)
+            return {"error": f"Device {ble_address} not found"}
+
+        # Use the internal method to discover services
+        from homeassistant.components.bluetooth import async_ble_device_from_address
+        from bleak import BleakClient
+        from bleak_retry_connector import establish_connection
+
+        try:
+            ble_device = async_ble_device_from_address(hass, device.address, connectable=True)
+            if not ble_device:
+                return {"error": "Could not get BLE device handle"}
+
+            client = await establish_connection(
+                BleakClient,
+                ble_device,
+                ble_device.name or ble_device.address,
+                max_attempts=2,
+            )
+
+            try:
+                discovery = await ble_client._log_device_services(client)
+                return {
+                    "address": device.address,
+                    "name": getattr(device, "name", "Unknown"),
+                    "services": discovery["services"],
+                    "found_wybot_service": discovery["found_primary_service"],
+                }
+            finally:
+                if client.is_connected:
+                    await client.disconnect()
+
+        except Exception as err:
+            _LOGGER.error("Service discovery failed: %s", err)
+            return {"error": str(err)}
+
+    async def handle_ble_wake(call: ServiceCall) -> ServiceResponse:
+        """Handle BLE wake service call."""
+        ble_address = call.data["ble_address"]
+        ble_client = WyBotBLEClient(hass)
+
+        _LOGGER.info("=== WyBot BLE Wake for %s ===", ble_address)
+
+        success = await ble_client.wake_device(ble_address)
+
+        return {
+            "address": ble_address,
+            "success": success,
+            "message": "Wake sequence complete" if success else "Wake failed",
+        }
+
+    async def handle_ble_query(call: ServiceCall) -> ServiceResponse:
+        """Handle BLE query status call."""
+        ble_address = call.data["ble_address"]
+        ble_client = WyBotBLEClient(hass)
+
+        _LOGGER.info("=== WyBot BLE Query for %s ===", ble_address)
+
+        dps = await ble_client.query_status(ble_address)
+
+        if dps:
+            return {
+                "address": ble_address,
+                "success": True,
+                "data_points": dps,
+            }
+        return {
+            "address": ble_address,
+            "success": False,
+            "error": "No response received",
+        }
+
+    # Register services
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_BLE_SCAN,
+        handle_ble_scan,
+        schema=vol.Schema({}),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_BLE_DISCOVER,
+        handle_ble_discover,
+        schema=SERVICE_BLE_ADDRESS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_BLE_WAKE,
+        handle_ble_wake,
+        schema=SERVICE_BLE_ADDRESS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_BLE_QUERY,
+        handle_ble_query,
+        schema=SERVICE_BLE_ADDRESS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    _LOGGER.info("WyBot BLE diagnostic services registered")
+
+    # Run automatic BLE scan on startup for diagnostics
+    async def run_startup_ble_scan():
+        """Run BLE scan on startup for diagnostics."""
+        await asyncio.sleep(10)  # Wait for Bluetooth to initialize
+        _LOGGER.info("=== Running startup BLE scan ===")
+        try:
+            from homeassistant.components.bluetooth import async_discovered_service_info, async_scanner_count
+
+            scanner_count = async_scanner_count(hass, connectable=True)
+            _LOGGER.info("Bluetooth scanner count: %d", scanner_count)
+
+            service_infos = async_discovered_service_info(hass, connectable=True)
+            _LOGGER.info("Total discovered BLE devices: %d", len(service_infos))
+
+            for info in service_infos:
+                device = info.device
+                is_wybot = False
+                if device.name and len(device.name) == 12:
+                    if all(c in "0123456789ABCDEFabcdef" for c in device.name):
+                        is_wybot = True
+
+                marker = " [WYBOT]" if is_wybot else ""
+                rssi = getattr(info, "rssi", "N/A")
+                _LOGGER.info(
+                    "  BLE Device%s: name=%s, address=%s, rssi=%s",
+                    marker,
+                    device.name or "Unknown",
+                    device.address,
+                    rssi,
+                )
+
+        except Exception as err:
+            _LOGGER.error("Startup BLE scan error: %s", err)
+
+    # Schedule the startup scan
+    hass.async_create_task(run_startup_ble_scan())
+
+    # Test: Send start cleaning command via BLE after startup
+    async def test_ble_start_cleaning():
+        """Test sending start cleaning command via BLE."""
+        await asyncio.sleep(20)  # Wait for BLE to fully initialize
+
+        _LOGGER.info("=" * 60)
+        _LOGGER.info("=== TEST: Sending START CLEANING command via BLE ===")
+        _LOGGER.info("=" * 60)
+
+        # Send to dock (dock relays commands to robot)
+        # DS20 Solar Dock: 3C8427565A1A
+        # S2 Pro Robot: CCBA97932A96
+        dock_ble_name = "3C8427565A1A"
+
+        try:
+            from .wybot_dp_models import DP, CleaningStatus, CleaningStatusMode
+
+            ble_client = WyBotBLEClient(hass)
+
+            # Create start cleaning command: DP 0, type 4, len 1, data "03"
+            start_cmd = CleaningStatus()
+            start_cmd.status = CleaningStatusMode.CLEANING  # Sets data to "03"
+
+            _LOGGER.info(
+                "Sending command: DP id=%d, type=%d, len=%d, data=%s",
+                start_cmd.id, start_cmd.type, start_cmd.len, start_cmd.data
+            )
+
+            success, response_dps = await ble_client.send_command(dock_ble_name, start_cmd)
+
+            if success:
+                _LOGGER.info("✓ Start cleaning command sent successfully!")
+                if response_dps:
+                    _LOGGER.info("Response DPs:")
+                    for dp in response_dps:
+                        _LOGGER.info("  DP %d: type=%d, len=%d, data=%s",
+                                    dp["id"], dp["type"], dp["len"], dp["data"])
+            else:
+                _LOGGER.warning("✗ Failed to send start cleaning command")
+
+        except Exception as err:
+            _LOGGER.error("Error in BLE start cleaning test: %s", err)
+
+        _LOGGER.info("=" * 60)
+        _LOGGER.info("=== END TEST ===")
+        _LOGGER.info("=" * 60)
+
+    # Run the start cleaning test on startup (RE-ENABLED - testing undock behavior)
+    hass.async_create_task(test_ble_start_cleaning())
+
+    # Add a service to trigger start cleaning via BLE
+    async def handle_ble_start_cleaning(call: ServiceCall) -> ServiceResponse:
+        """Handle BLE start cleaning service call."""
+        ble_address = call.data.get("ble_address", "3C8427565A1A")  # Default to dock
+
+        _LOGGER.info("=== BLE Start Cleaning Command ===")
+        _LOGGER.info("Target device: %s", ble_address)
+
+        try:
+            from .wybot_dp_models import CleaningStatus, CleaningStatusMode
+
+            ble_client = WyBotBLEClient(hass)
+
+            # Create start cleaning command
+            start_cmd = CleaningStatus()
+            start_cmd.status = CleaningStatusMode.CLEANING
+
+            _LOGGER.info(
+                "Sending: DP id=%d, type=%d, len=%d, data=%s",
+                start_cmd.id, start_cmd.type, start_cmd.len, start_cmd.data
+            )
+
+            success, response_dps = await ble_client.send_command(ble_address, start_cmd)
+
+            return {
+                "address": ble_address,
+                "success": success,
+                "command": "start_cleaning",
+                "dp_sent": {"id": 0, "type": 4, "len": 1, "data": "03"},
+                "response_dps": response_dps if response_dps else [],
+            }
+
+        except Exception as err:
+            _LOGGER.error("BLE start cleaning error: %s", err)
+            return {"error": str(err), "success": False}
+
+    async def handle_ble_stop_cleaning(call: ServiceCall) -> ServiceResponse:
+        """Handle BLE stop cleaning service call."""
+        ble_address = call.data.get("ble_address", "3C8427565A1A")
+
+        _LOGGER.info("=== BLE Stop Cleaning Command ===")
+
+        try:
+            from .wybot_dp_models import CleaningStatus, CleaningStatusMode
+
+            ble_client = WyBotBLEClient(hass)
+
+            stop_cmd = CleaningStatus()
+            stop_cmd.status = CleaningStatusMode.STOPPED
+
+            success, response_dps = await ble_client.send_command(ble_address, stop_cmd)
+
+            return {
+                "address": ble_address,
+                "success": success,
+                "command": "stop_cleaning",
+                "dp_sent": {"id": 0, "type": 4, "len": 1, "data": "01"},
+                "response_dps": response_dps if response_dps else [],
+            }
+
+        except Exception as err:
+            _LOGGER.error("BLE stop cleaning error: %s", err)
+            return {"error": str(err), "success": False}
+
+    # Register cleaning control services
+    hass.services.async_register(
+        DOMAIN,
+        "ble_start_cleaning",
+        handle_ble_start_cleaning,
+        schema=vol.Schema({
+            vol.Optional("ble_address", default="3C8427565A1A"): cv.string,
+        }),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        "ble_stop_cleaning",
+        handle_ble_stop_cleaning,
+        schema=vol.Schema({
+            vol.Optional("ble_address", default="3C8427565A1A"): cv.string,
+        }),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    _LOGGER.info("WyBot BLE cleaning control services registered")
+
+    return True

--- a/custom_components/wybot/binary_sensor.py
+++ b/custom_components/wybot/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Platform for binary sensor integration."""
+"""Binary sensor platform for WyBot integration."""
 
 from __future__ import annotations
 
@@ -10,16 +10,25 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
 from .wybot_coordinator import WyBotCoordinator
-from .wybot_dp_models import Battery, BatteryState
+from .wybot_dp_models import Battery, BatteryState, DockConnectionStatus, SolarStatus
 from .wybot_models import Group
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def format_mac(mac: str) -> str:
+    """Format a MAC address string with colons.
+
+    Converts "CCBA97932A96" to "CC:BA:97:93:2A:96".
+    """
+    mac = mac.upper().replace(":", "").replace("-", "")
+    return ":".join(mac[i : i + 2] for i in range(0, 12, 2))
 
 
 async def async_setup_entry(
@@ -27,33 +36,36 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the binary sensor platform."""
+    """Set up the WyBot binary sensor platform."""
     coordinator: WyBotCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        WyBotChargingSensor(idx=deviceId, coordinator=coordinator)
-        for deviceId in coordinator.vacuums
-    )
+
+    entities: list[BinarySensorEntity] = []
+
+    for device_id in coordinator.vacuums:
+        entities.extend(
+            [
+                WyBotRobotChargingBinarySensor(idx=device_id, coordinator=coordinator),
+                WyBotDockChargingBinarySensor(idx=device_id, coordinator=coordinator),
+            ]
+        )
+
+    async_add_entities(entities)
 
 
-class WyBotChargingSensor(CoordinatorEntity, BinarySensorEntity):
-    """A WyBot charging binary sensor."""
+class WyBotBinarySensorBase(BinarySensorEntity, CoordinatorEntity):
+    """Base class for WyBot binary sensors."""
 
-    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
-    _attr_has_entity_name = True
-
-    _data: Group
+    _data: Group | None
     _idx: str
     _coordinator: WyBotCoordinator
+    _attr_has_entity_name = True
 
     def __init__(self, idx: str, coordinator: WyBotCoordinator) -> None:
-        """Initialize the WyBot charging sensor."""
+        """Initialize the WyBot binary sensor."""
         super().__init__(coordinator=coordinator, context=idx)
         self._idx = idx
         self._coordinator = coordinator
-        # Initialize data safely
         self._data = coordinator.data.get(self._idx) if coordinator.data else None
-        self._attr_unique_id = f"wybot_charging_{self._idx}"
-        self._attr_translation_key = "charging"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -67,42 +79,157 @@ class WyBotChargingSensor(CoordinatorEntity, BinarySensorEntity):
         """Return if entity is available."""
         if not self.coordinator.available:
             return False
-        # Check coordinator data directly if local data not set
-        if not self._data and str(self._idx) in self.coordinator.data:
-            self._data = self.coordinator.data[str(self._idx)]
         if not self._data:
             return False
         if str(self._idx) not in self.coordinator.data:
             return False
         return True
 
+    def _get_robot_name(self) -> str:
+        """Get the robot device name."""
+        if self._data:
+            if self._data.name:
+                return self._data.name
+            elif self._data.device and self._data.device.device_name:
+                return self._data.device.device_name
+            elif self._data.device and self._data.device.device_type:
+                return self._data.device.device_type
+        return "Unknown"
+
+    def _get_robot_model(self) -> str:
+        """Get the robot device model."""
+        if self._data and self._data.device:
+            return self._data.device.device_type
+        return "Unknown"
+
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device information."""
-        name = self._data.name if self._data else "Unknown"
-        model = (
-            self._data.device.device_type
-            if self._data and self._data.device
-            else "Unknown"
-        )
+        """Return device information for the robot."""
+        connections: set[tuple[str, str]] = set()
+        if self._data and self._data.device and self._data.device.ble_name:
+            connections.add(
+                (CONNECTION_BLUETOOTH, format_mac(self._data.device.ble_name))
+            )
+        # If dock exists, robot connects via dock; otherwise standalone
+        via_device = None
+        if self._data and self._data.docker:
+            via_device = (DOMAIN, f"{self._idx}_dock")
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._idx))},
-            name=name,
+            name=self._get_robot_name(),
             manufacturer=MANUFACTURER,
-            model=model,
+            model=self._get_robot_model(),
+            connections=connections if connections else None,
+            via_device=via_device,
         )
+
+
+class WyBotRobotChargingBinarySensor(WyBotBinarySensorBase):
+    """Binary sensor for robot charging status."""
+
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    _attr_translation_key = "robot_charging"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_robot_charging"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Charging"
 
     @property
     def is_on(self) -> bool | None:
-        """Return True if the vacuum is charging."""
-        # Get data from coordinator if not set locally
-        if not self._data and str(self._idx) in self.coordinator.data:
-            self._data = self.coordinator.data[str(self._idx)]
-
+        """Return True if the robot is charging."""
         if not self._data:
             return None
         battery = self._data.get_dp(Battery)
         if battery is None:
             return None
-        return battery.charge_state in (BatteryState.CHARGING, BatteryState.CHARGED)
+        return battery.charge_state == BatteryState.CHARGING
 
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return additional state attributes."""
+        attrs = {}
+        if self._data:
+            battery = self._data.get_dp(Battery)
+            if battery is not None:
+                attrs["charge_state"] = battery.charge_state.name
+                attrs["is_fully_charged"] = (
+                    battery.charge_state == BatteryState.CHARGED
+                )
+        return attrs
+
+
+class WyBotDockBinarySensorBase(WyBotBinarySensorBase):
+    """Base class for WyBot dock binary sensors - creates a separate dock device."""
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for the solar dock."""
+        dock_name = "Solar Dock"
+        dock_model = "Unknown"
+        connections: set[tuple[str, str]] = set()
+        if self._data and self._data.docker:
+            dock_model = self._data.docker.docker_type
+            # Use docker type as name if available
+            if self._data.docker.docker_type:
+                dock_name = f"{self._data.docker.docker_type} Solar Dock"
+            # Add Bluetooth MAC connection if available
+            if self._data.docker.ble_name:
+                connections.add(
+                    (CONNECTION_BLUETOOTH, format_mac(self._data.docker.ble_name))
+                )
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._idx}_dock")},
+            name=dock_name,
+            manufacturer=MANUFACTURER,
+            model=dock_model,
+            connections=connections if connections else None,
+        )
+
+
+class WyBotDockChargingBinarySensor(WyBotDockBinarySensorBase):
+    """Binary sensor for dock solar charging status."""
+
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    _attr_translation_key = "dock_charging"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_dock_charging"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Charging"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the dock is charging (solar)."""
+        if not self._data:
+            return None
+        solar_status = self._data.get_dp(SolarStatus)
+        if solar_status is None:
+            return None
+        return solar_status.is_charging
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return additional state attributes."""
+        attrs = {}
+        if self._data:
+            # Add dock connection status
+            dock_status = self._data.get_dp(DockConnectionStatus)
+            if dock_status is not None:
+                attrs["is_docked"] = dock_status.is_docked
+
+            # Add solar status raw value
+            solar_status = self._data.get_dp(SolarStatus)
+            if solar_status is not None:
+                attrs["raw_value"] = solar_status.data
+        return attrs

--- a/custom_components/wybot/button.py
+++ b/custom_components/wybot/button.py
@@ -1,0 +1,108 @@
+"""Button platform for WyBot integration."""
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_WIFI_PASSWORD, CONF_WIFI_SSID, DOMAIN
+from .wybot_coordinator import WyBotCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up WyBot buttons from a config entry."""
+    coordinator: WyBotCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[ButtonEntity] = []
+
+    # Get WiFi credentials from config entry
+    wifi_ssid = config_entry.data.get(CONF_WIFI_SSID)
+    wifi_password = config_entry.data.get(CONF_WIFI_PASSWORD)
+
+    # Add WiFi reconfigure button for each dock device (if credentials configured)
+    for idx in coordinator.vacuums:
+        group = coordinator.data.get(idx)
+        # Only create button if there's a dock with a BLE name and WiFi credentials
+        if (
+            group
+            and group.docker
+            and group.docker.ble_name
+            and wifi_ssid
+            and wifi_password
+        ):
+            entities.append(
+                WyBotWifiReconfigureButton(
+                    coordinator,
+                    idx,
+                    group.docker.ble_name,
+                    wifi_ssid,
+                    wifi_password,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class WyBotWifiReconfigureButton(CoordinatorEntity[WyBotCoordinator], ButtonEntity):
+    """Diagnostic button to manually send WiFi credentials to a WyBot device via BLE."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "wifi_reconfigure"
+    _attr_name = "Send WiFi credentials"  # Fallback name if translations not loaded
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False  # Disabled by default
+    coordinator: WyBotCoordinator
+
+    def __init__(
+        self,
+        coordinator: WyBotCoordinator,
+        idx: str,
+        ble_name: str,
+        wifi_ssid: str,
+        wifi_password: str,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._idx = idx
+        self._ble_name = ble_name
+        self._wifi_ssid = wifi_ssid
+        self._wifi_password = wifi_password
+        self._attr_unique_id = f"{idx}_dock_wifi_reconfigure_button"
+        self._attr_icon = "mdi:wifi-cog"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information - associates with the dock device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._idx}_dock")},
+        )
+
+    async def async_press(self) -> None:
+        """Handle the button press - sends WiFi credentials to the dock via BLE."""
+        _LOGGER.info(
+            "WiFi reconfigure button pressed, sending credentials to dock %s (SSID: %s)",
+            self._ble_name,
+            self._wifi_ssid,
+        )
+        success = await self.coordinator.wybot_ble_client.configure_wifi(
+            self._ble_name, self._wifi_ssid, self._wifi_password
+        )
+        if success:
+            _LOGGER.info(
+                "Successfully sent WiFi credentials to dock %s", self._ble_name
+            )
+        else:
+            _LOGGER.warning(
+                "Failed to send WiFi credentials to dock %s via BLE", self._ble_name
+            )

--- a/custom_components/wybot/config_flow.py
+++ b/custom_components/wybot/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Hubspace integration."""
+"""Config flow for WyBot integration."""
 
 from __future__ import annotations
 
@@ -7,21 +7,33 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import format_mac
 
-from .const import DOMAIN
+from .const import CONF_WIFI_PASSWORD, CONF_WIFI_SSID, DOMAIN
 from .wybot_http_client import WyBotHTTPClient
 
 _LOGGER = logging.getLogger(__name__)
+
+# Key for storing discovered device info in config entry data
+CONF_DISCOVERED_DEVICE_ADDRESS = "discovered_device_address"
+CONF_DISCOVERED_DEVICE_NAME = "discovered_device_name"
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_WIFI_SSID): str,
+        vol.Optional(CONF_WIFI_PASSWORD): str,
     }
 )
 
@@ -42,31 +54,134 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     return {"title": data[CONF_USERNAME]}
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class WyBotConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for WyBot."""
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: BluetoothServiceInfoBleak | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> OptionsFlow:
+        """Create the options flow."""
+        return OptionsFlowHandler()
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> ConfigFlowResult:
+        """Handle Bluetooth discovery.
+
+        This is triggered when a DS20 dock is discovered via Bluetooth.
+        Only DS20 docks (with prefix "DS20-") are auto-discovered because robots
+        advertise as raw MAC addresses which could match other BLE devices.
+        """
+        _LOGGER.info(
+            "Bluetooth discovery: name=%s, address=%s",
+            discovery_info.name,
+            discovery_info.address,
+        )
+
+        # Use the MAC address as unique ID
+        await self.async_set_unique_id(format_mac(discovery_info.address))
+        self._abort_if_unique_id_configured()
+
+        # Store discovery info for later use
+        self._discovery_info = discovery_info
+
+        # Determine device type from name
+        device_type = "DS20 Dock" if discovery_info.name.startswith("DS20-") else "Robot"
+        self.context["title_placeholders"] = {"name": f"WyBot {device_type}"}
+
+        # Proceed to user step to collect credentials
+        return await self.async_step_user()
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            try:
-                info = await validate_input(self.hass, user_input)
-            except CannotConnect:
-                errors["base"] = "Cannot Connect"
-            except InvalidAuth:
-                errors["base"] = "Invalid User and Password"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "Unknown error"
+            # Validate WiFi fields: if SSID is provided, password is required
+            wifi_ssid = user_input.get(CONF_WIFI_SSID)
+            wifi_password = user_input.get(CONF_WIFI_PASSWORD)
+            if wifi_ssid and not wifi_password:
+                errors["base"] = "wifi_password_required"
             else:
-                return self.async_create_entry(title=info["title"], data=user_input)
+                try:
+                    info = await validate_input(self.hass, user_input)
+                except CannotConnect:
+                    errors["base"] = "cannot_connect"
+                except InvalidAuth:
+                    errors["base"] = "invalid_auth"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected exception")
+                    errors["base"] = "unknown"
+                else:
+                    # Include discovered device info if available
+                    entry_data = dict(user_input)
+                    if self._discovery_info:
+                        entry_data[CONF_DISCOVERED_DEVICE_ADDRESS] = (
+                            self._discovery_info.address
+                        )
+                        entry_data[CONF_DISCOVERED_DEVICE_NAME] = (
+                            self._discovery_info.name
+                        )
+                    return self.async_create_entry(title=info["title"], data=entry_data)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+
+class OptionsFlowHandler(OptionsFlow):
+    """Handle options flow for WyBot."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the WiFi options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Validate WiFi fields: if SSID is provided, password is required
+            wifi_ssid = user_input.get(CONF_WIFI_SSID)
+            wifi_password = user_input.get(CONF_WIFI_PASSWORD)
+            if wifi_ssid and not wifi_password:
+                errors["base"] = "wifi_password_required"
+            else:
+                # Update config entry data with new WiFi credentials
+                new_data = {**self.config_entry.data}
+                if wifi_ssid:
+                    new_data[CONF_WIFI_SSID] = wifi_ssid
+                    new_data[CONF_WIFI_PASSWORD] = wifi_password
+                else:
+                    # Remove WiFi credentials if SSID is cleared
+                    new_data.pop(CONF_WIFI_SSID, None)
+                    new_data.pop(CONF_WIFI_PASSWORD, None)
+
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=new_data
+                )
+                return self.async_create_entry(title="", data={})
+
+        # Get current values for the form
+        current_ssid = self.config_entry.data.get(CONF_WIFI_SSID, "")
+        current_password = self.config_entry.data.get(CONF_WIFI_PASSWORD, "")
+
+        options_schema = vol.Schema(
+            {
+                vol.Optional(CONF_WIFI_SSID, default=current_ssid): str,
+                vol.Optional(CONF_WIFI_PASSWORD, default=current_password): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init", data_schema=options_schema, errors=errors
         )
 
 

--- a/custom_components/wybot/const.py
+++ b/custom_components/wybot/const.py
@@ -3,3 +3,12 @@
 DOMAIN = "wybot"
 TIMEOUT = 30
 MANUFACTURER = "WyBot"
+
+# WiFi configuration constants (for manual WiFi provisioning via diagnostic button)
+CONF_WIFI_SSID = "wifi_ssid"
+CONF_WIFI_PASSWORD = "wifi_password"
+
+# BLE command configuration
+BLE_COMMAND_TIMEOUT = 25.0  # seconds (includes connection + status wait + CleaningMode query)
+BLE_COMMAND_HOLD_TIME = 2.0  # seconds to wait after write for acknowledgment
+BLE_MAX_CONSECUTIVE_FAILURES = 3  # disable BLE commands after N consecutive failures

--- a/custom_components/wybot/manifest.json
+++ b/custom_components/wybot/manifest.json
@@ -1,15 +1,20 @@
 {
   "domain": "wybot",
   "name": "WyBot",
+  "bluetooth": [
+    {
+      "local_name": "DS20-*"
+    }
+  ],
   "codeowners": ["@bassrock"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["bluetooth_adapters"],
   "documentation": "https://github.com/bassrock/hass-wybot",
   "homekit": {},
   "iot_class": "cloud_push",
-  "requirements": ["pydantic", "paho-mqtt"],
+  "requirements": ["pydantic", "paho-mqtt", "bleak"],
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.3.0",
+  "version": "2.0.0",
   "loggers": ["custom_components.wybot"]
 }

--- a/custom_components/wybot/manifest.json
+++ b/custom_components/wybot/manifest.json
@@ -10,11 +10,9 @@
   "config_flow": true,
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://github.com/bassrock/hass-wybot",
-  "homekit": {},
+  "integration_type": "device",
   "iot_class": "cloud_push",
   "requirements": ["pydantic", "paho-mqtt", "bleak"],
-  "ssdp": [],
-  "zeroconf": [],
   "version": "2.0.0",
   "loggers": ["custom_components.wybot"]
 }

--- a/custom_components/wybot/sensor.py
+++ b/custom_components/wybot/sensor.py
@@ -1,8 +1,8 @@
-"""Platform for sensor integration."""
+"""Sensor platform for WyBot integration."""
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 
 from homeassistant.components.sensor import (
@@ -11,24 +11,32 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, MANUFACTURER
 from .wybot_coordinator import WyBotCoordinator
-from .wybot_dp_models import Battery, BatteryState
+from .wybot_dp_models import (
+    Battery,
+    DockInfo,
+    SolarDockBattery,
+    SolarEnergyHarvested,
+)
 from .wybot_models import Group
 
 _LOGGER = logging.getLogger(__name__)
 
-# Force state write every 5 minutes to ensure history is recorded
-FORCE_STATE_WRITE_INTERVAL = timedelta(minutes=5)
+
+def format_mac(mac: str) -> str:
+    """Format a MAC address string with colons.
+
+    Converts "CCBA97932A96" to "CC:BA:97:93:2A:96".
+    """
+    mac = mac.upper().replace(":", "").replace("-", "")
+    return ":".join(mac[i : i + 2] for i in range(0, 12, 2))
 
 
 async def async_setup_entry(
@@ -36,143 +44,150 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the sensor platform."""
+    """Set up the WyBot sensor platform."""
     coordinator: WyBotCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        WyBotBatterySensor(idx=deviceId, coordinator=coordinator)
-        for deviceId in coordinator.vacuums
-    )
+
+    entities: list[SensorEntity] = []
+
+    for device_id in coordinator.vacuums:
+        # Add sensors for each device
+        entities.extend(
+            [
+                WyBotRobotBatterySensor(idx=device_id, coordinator=coordinator),
+                WyBotSolarDockBatterySensor(idx=device_id, coordinator=coordinator),
+                WyBotSolarEnergySensor(idx=device_id, coordinator=coordinator),
+                WyBotDockTypeSensor(idx=device_id, coordinator=coordinator),
+                # Diagnostic sensors for communication tracking
+                WyBotLastBLECommunicationSensor(idx=device_id, coordinator=coordinator),
+                WyBotLastMQTTCommunicationSensor(idx=device_id, coordinator=coordinator),
+                WyBotDataSourceSensor(idx=device_id, coordinator=coordinator),
+            ]
+        )
+
+    async_add_entities(entities)
 
 
-class WyBotBatterySensor(CoordinatorEntity, SensorEntity):
-    """A WyBot battery sensor."""
+class WyBotSensorBase(SensorEntity, CoordinatorEntity):
+    """Base class for WyBot sensors."""
 
-    _attr_device_class = SensorDeviceClass.BATTERY
-    _attr_native_unit_of_measurement = PERCENTAGE
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_has_entity_name = True
-
-    _data: Group
+    _data: Group | None
     _idx: str
     _coordinator: WyBotCoordinator
-    _last_state_write: datetime | None = None
-    _last_charging_state: BatteryState | None = None
-    _last_availability: bool | None = None
+    _attr_has_entity_name = True
 
     def __init__(self, idx: str, coordinator: WyBotCoordinator) -> None:
-        """Initialize the WyBot battery sensor."""
+        """Initialize the WyBot sensor."""
         super().__init__(coordinator=coordinator, context=idx)
         self._idx = idx
         self._coordinator = coordinator
-        # Initialize data safely
         self._data = coordinator.data.get(self._idx) if coordinator.data else None
-        self._attr_unique_id = f"wybot_battery_{self._idx}"
-        self._attr_translation_key = "battery"
-        self._last_state_write = None
-        self._last_charging_state = None
-        self._last_availability = None
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if str(self._idx) in self.coordinator.data:
             self._data = self.coordinator.data[str(self._idx)]
-
-        # Track availability changes
-        current_availability = self.available
-        previous_availability = self._last_availability
-        availability_changed = (
-            previous_availability is not None
-            and previous_availability != current_availability
-        )
-        self._last_availability = current_availability
-
-        # Track charging state changes
-        current_charging_state = None
-        if self._data:
-            battery = self._data.get_dp(Battery)
-            if battery is not None:
-                current_charging_state = battery.charge_state
-        previous_charging_state = self._last_charging_state
-        charging_state_changed = (
-            previous_charging_state is not None
-            and previous_charging_state != current_charging_state
-        )
-        self._last_charging_state = current_charging_state
-
-        # Always write state if:
-        # 1. Availability changed (to record unavailable/available transitions)
-        # 2. Charging state changed (to update icon and attributes)
-        # 3. It's been more than FORCE_STATE_WRITE_INTERVAL since last write (to ensure history)
-        # 4. Normal coordinator update (base class handles this)
-        now = dt_util.utcnow()
-        should_force_write = (
-            availability_changed
-            or charging_state_changed
-            or self._last_state_write is None
-            or (now - self._last_state_write) >= FORCE_STATE_WRITE_INTERVAL
-        )
-
-        # Call base class update handler
         super()._handle_coordinator_update()
-
-        # Force state write if needed to ensure icon and attributes update
-        if should_force_write:
-            self.async_write_ha_state()
-            self._last_state_write = now
-            if availability_changed:
-                _LOGGER.debug(
-                    "Availability changed for %s: %s -> %s, forcing state write",
-                    self.entity_id,
-                    previous_availability,
-                    current_availability,
-                )
-            if charging_state_changed:
-                _LOGGER.debug(
-                    "Charging state changed for %s: %s -> %s, forcing state write",
-                    self.entity_id,
-                    previous_charging_state,
-                    current_charging_state,
-                )
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
         if not self.coordinator.available:
             return False
-        # Check coordinator data directly if local data not set
-        if not self._data and str(self._idx) in self.coordinator.data:
-            self._data = self.coordinator.data[str(self._idx)]
         if not self._data:
             return False
         if str(self._idx) not in self.coordinator.data:
             return False
         return True
 
+    def _get_robot_name(self) -> str:
+        """Get the robot device name."""
+        if self._data:
+            if self._data.name:
+                return self._data.name
+            elif self._data.device and self._data.device.device_name:
+                return self._data.device.device_name
+            elif self._data.device and self._data.device.device_type:
+                return self._data.device.device_type
+        return "Unknown"
+
+    def _get_robot_model(self) -> str:
+        """Get the robot device model."""
+        if self._data and self._data.device:
+            return self._data.device.device_type
+        return "Unknown"
+
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device information."""
-        name = self._data.name if self._data else "Unknown"
-        model = (
-            self._data.device.device_type
-            if self._data and self._data.device
-            else "Unknown"
-        )
+        """Return device information for the robot."""
+        connections: set[tuple[str, str]] = set()
+        if self._data and self._data.device and self._data.device.ble_name:
+            connections.add(
+                (CONNECTION_BLUETOOTH, format_mac(self._data.device.ble_name))
+            )
+        # If dock exists, robot connects via dock; otherwise standalone
+        via_device = None
+        if self._data and self._data.docker:
+            via_device = (DOMAIN, f"{self._idx}_dock")
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._idx))},
-            name=name,
+            name=self._get_robot_name(),
             manufacturer=MANUFACTURER,
-            model=model,
+            model=self._get_robot_model(),
+            connections=connections if connections else None,
+            via_device=via_device,
         )
+
+
+class WyBotDockSensorBase(WyBotSensorBase):
+    """Base class for WyBot dock sensors - creates a separate dock device."""
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for the solar dock."""
+        dock_name = "Solar Dock"
+        dock_model = "Unknown"
+        connections: set[tuple[str, str]] = set()
+        if self._data and self._data.docker:
+            dock_model = self._data.docker.docker_type
+            # Use docker type as name if available
+            if self._data.docker.docker_type:
+                dock_name = f"{self._data.docker.docker_type} Solar Dock"
+            # Add Bluetooth MAC connection if available
+            if self._data.docker.ble_name:
+                connections.add(
+                    (CONNECTION_BLUETOOTH, format_mac(self._data.docker.ble_name))
+                )
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._idx}_dock")},
+            name=dock_name,
+            manufacturer=MANUFACTURER,
+            model=dock_model,
+            connections=connections if connections else None,
+        )
+
+
+class WyBotRobotBatterySensor(WyBotSensorBase):
+    """Sensor for robot battery level."""
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_translation_key = "robot_battery"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_robot_battery"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Robot battery"
 
     @property
     def native_value(self) -> int | None:
-        """Return the battery level of the vacuum cleaner."""
-        # Get data from coordinator if not set locally
-        if not self._data and str(self._idx) in self.coordinator.data:
-            self._data = self.coordinator.data[str(self._idx)]
-
+        """Return the robot battery level as percentage."""
         if not self._data:
             return None
         battery = self._data.get_dp(Battery)
@@ -180,24 +195,249 @@ class WyBotBatterySensor(CoordinatorEntity, SensorEntity):
             return None
         return battery.battery_level
 
+
+class WyBotSolarDockBatterySensor(WyBotDockSensorBase):
+    """Sensor for solar dock battery level."""
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_translation_key = "dock_battery"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_dock_battery"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Battery"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the solar dock battery level as percentage."""
+        if not self._data:
+            return None
+        dock_battery = self._data.get_dp(SolarDockBattery)
+        if dock_battery is None:
+            return None
+        return dock_battery.battery_level
+
+
+class WyBotSolarEnergySensor(WyBotDockSensorBase):
+    """Sensor for total solar energy harvested."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+    _attr_translation_key = "solar_energy"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_solar_energy"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Energy harvested"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the total solar energy harvested in Wh."""
+        if not self._data:
+            return None
+        solar_energy = self._data.get_dp(SolarEnergyHarvested)
+        if solar_energy is None:
+            return None
+        return solar_energy.energy_wh
+
+
+class WyBotDockTypeSensor(WyBotDockSensorBase):
+    """Sensor for dock type information."""
+
+    _attr_device_class = None
+    _attr_entity_registry_enabled_default = False  # Disabled by default (diagnostic)
+    _attr_translation_key = "dock_type"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_dock_type"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Type"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the dock type."""
+        if not self._data:
+            return None
+        dock_info = self._data.get_dp(DockInfo)
+        if dock_info is None:
+            return None
+        if dock_info.is_solar_dock:
+            return "Solar"
+        return dock_info.dock_type.name.title()
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return additional state attributes."""
+        attrs = {}
+        if self._data:
+            dock_info = self._data.get_dp(DockInfo)
+            if dock_info is not None:
+                attrs["raw_value"] = dock_info.data
+                attrs["is_solar_dock"] = dock_info.is_solar_dock
+        return attrs
+
+
+class WyBotLastBLECommunicationSensor(WyBotDockSensorBase):
+    """Diagnostic sensor for last BLE communication time."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = True
+    _attr_translation_key = "last_ble_communication"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_last_ble_communication"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Last BLE communication"
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the last BLE communication time."""
+        # Get the dock device ID for BLE tracking (dock relays to robot)
+        if self._data and self._data.docker:
+            device_id = self._data.docker.docker_id
+        elif self._data and self._data.device:
+            device_id = self._data.device.device_id
+        else:
+            return None
+        return self._coordinator.get_last_ble_communication(device_id)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return additional state attributes."""
+        attrs = {}
+        if self._data and self._data.docker:
+            device_id = self._data.docker.docker_id
+            attrs["ble_available"] = self._coordinator.is_ble_available(device_id)
+            if self._data.docker.ble_name:
+                attrs["ble_name"] = self._data.docker.ble_name
+        return attrs
+
+
+class WyBotLastMQTTCommunicationSensor(WyBotDockSensorBase):
+    """Diagnostic sensor for last MQTT communication time."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = True
+    _attr_translation_key = "last_mqtt_communication"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_last_mqtt_communication"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Last MQTT communication"
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the last MQTT communication time."""
+        # Get the dock device ID for MQTT tracking
+        if self._data and self._data.docker:
+            device_id = self._data.docker.docker_id
+        elif self._data and self._data.device:
+            device_id = self._data.device.device_id
+        else:
+            return None
+        return self._coordinator.get_last_mqtt_communication(device_id)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return additional state attributes."""
+        attrs = {}
+        if self._data and self._data.docker:
+            attrs["mqtt_connected"] = self._coordinator._mqtt_connected
+        return attrs
+
+
+class WyBotDataSourceSensor(WyBotDockSensorBase):
+    """Diagnostic sensor showing current data source (BLE or MQTT)."""
+
+    _attr_device_class = None
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = True
+    _attr_translation_key = "data_source"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_data_source"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Data source"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current data source."""
+        if self._data and self._data.docker:
+            device_id = self._data.docker.docker_id
+        elif self._data and self._data.device:
+            device_id = self._data.device.device_id
+        else:
+            return None
+        source = self._coordinator.get_data_source(device_id)
+        if source == "ble":
+            return "Bluetooth"
+        elif source == "mqtt":
+            return "Cloud (MQTT)"
+        return "Unknown"
+
     @property
     def icon(self) -> str:
-        """Return the icon for the battery sensor."""
-        battery = self._data.get_dp(Battery) if self._data else None
-        if battery is None:
-            return "mdi:battery-unknown"
-        battery_level = battery.battery_level
-        is_charging = battery.charge_state in (BatteryState.CHARGING, BatteryState.CHARGED)
-        return icon_for_battery_level(battery_level=battery_level, charging=is_charging)
+        """Return the icon based on data source."""
+        if self._data and self._data.docker:
+            device_id = self._data.docker.docker_id
+        elif self._data and self._data.device:
+            device_id = self._data.device.device_id
+        else:
+            return "mdi:help-circle"
+        source = self._coordinator.get_data_source(device_id)
+        if source == "ble":
+            return "mdi:bluetooth"
+        elif source == "mqtt":
+            return "mdi:cloud"
+        return "mdi:help-circle"
 
     @property
-    def extra_state_attributes(self) -> dict[str, str]:
-        """Return extra state attributes."""
-        battery = self._data.get_dp(Battery) if self._data else None
-        if battery is None:
-            return {}
-        return {
-            "charging": battery.charge_state in (BatteryState.CHARGING, BatteryState.CHARGED),
-            "charge_state": battery.charge_state.name,
-        }
-
+    def extra_state_attributes(self) -> dict:
+        """Return additional state attributes."""
+        attrs = {}
+        if self._data and self._data.docker:
+            device_id = self._data.docker.docker_id
+            attrs["ble_available"] = self._coordinator.is_ble_available(device_id)
+            attrs["mqtt_connected"] = self._coordinator._mqtt_connected
+            last_ble = self._coordinator.get_last_ble_communication(device_id)
+            last_mqtt = self._coordinator.get_last_mqtt_communication(device_id)
+            if last_ble:
+                attrs["last_ble"] = last_ble.isoformat()
+            if last_mqtt:
+                attrs["last_mqtt"] = last_mqtt.isoformat()
+        return attrs

--- a/custom_components/wybot/services.yaml
+++ b/custom_components/wybot/services.yaml
@@ -1,0 +1,42 @@
+# WyBot Integration Services
+
+ble_scan:
+  name: BLE Scan
+  description: Scan for WyBot BLE devices using Home Assistant's Bluetooth integration
+  fields: {}
+
+ble_discover:
+  name: BLE Discover Services
+  description: Connect to a WyBot device and discover its BLE services/characteristics
+  fields:
+    ble_address:
+      name: BLE Address
+      description: Device MAC address (e.g., CC:BA:97:93:2A:96) or BLE name (e.g., CCBA97932A96)
+      required: true
+      example: "CCBA97932A96"
+      selector:
+        text:
+
+ble_wake:
+  name: BLE Wake Device
+  description: Wake a WyBot device via BLE connection
+  fields:
+    ble_address:
+      name: BLE Address
+      description: Device MAC address or BLE name
+      required: true
+      example: "CCBA97932A96"
+      selector:
+        text:
+
+ble_query:
+  name: BLE Query Status
+  description: Query device status via BLE and log the response
+  fields:
+    ble_address:
+      name: BLE Address
+      description: Device MAC address or BLE name
+      required: true
+      example: "CCBA97932A96"
+      selector:
+        text:

--- a/custom_components/wybot/strings.json
+++ b/custom_components/wybot/strings.json
@@ -1,15 +1,88 @@
 {
+  "config": {
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "title": "WyBot account",
+        "description": "Enter your WyBot account credentials. WiFi settings are optional and used for manual WiFi provisioning via the diagnostic button.",
+        "data": {
+          "username": "Email",
+          "password": "Password",
+          "wifi_ssid": "WiFi network name (optional)",
+          "wifi_password": "WiFi password (optional)"
+        },
+        "data_description": {
+          "wifi_ssid": "The WiFi network name your WyBot device should connect to. Used for manual WiFi provisioning via the diagnostic button.",
+          "wifi_password": "The WiFi password for the network. Required if WiFi SSID is provided."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to WyBot",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error",
+      "wifi_password_required": "WiFi password is required when WiFi SSID is provided"
+    },
+    "abort": {
+      "already_configured": "Account is already configured",
+      "already_in_progress": "Configuration flow is already in progress"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "WyBot WiFi settings",
+        "description": "Configure WiFi credentials for manual provisioning. Enable the 'Send WiFi credentials' diagnostic button on your device to manually send these credentials via Bluetooth when needed.",
+        "data": {
+          "wifi_ssid": "WiFi network name",
+          "wifi_password": "WiFi password"
+        },
+        "data_description": {
+          "wifi_ssid": "The WiFi network name your WyBot device should connect to.",
+          "wifi_password": "The WiFi password for the network."
+        }
+      }
+    },
+    "error": {
+      "wifi_password_required": "WiFi password is required when WiFi SSID is provided"
+    }
+  },
   "entity": {
     "binary_sensor": {
-      "charging": {
+      "robot_charging": {
+        "name": "Charging"
+      },
+      "dock_charging": {
         "name": "Charging"
       }
     },
+    "button": {
+      "wifi_reconfigure": {
+        "name": "Send WiFi credentials"
+      }
+    },
     "sensor": {
-      "battery": {
-        "name": "Battery"
+      "robot_battery": {
+        "name": "Robot battery"
+      },
+      "dock_battery": {
+        "name": "Dock battery"
+      },
+      "solar_energy": {
+        "name": "Solar energy harvested"
+      },
+      "dock_type": {
+        "name": "Dock type"
+      },
+      "last_ble_communication": {
+        "name": "Last BLE communication"
+      },
+      "last_mqtt_communication": {
+        "name": "Last MQTT communication"
+      },
+      "data_source": {
+        "name": "Data source"
       }
     }
   }
 }
-

--- a/custom_components/wybot/vacuum.py
+++ b/custom_components/wybot/vacuum.py
@@ -12,7 +12,7 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -26,6 +26,7 @@ from .wybot_dp_models import (
     CleaningStatus,
     CleaningStatusMode,
     Dock,
+    DockConnectionStatus,
     DockStatus,
 )
 from .wybot_models import Group
@@ -34,6 +35,15 @@ _LOGGER = logging.getLogger(__name__)
 
 # Force state write every 5 minutes to ensure history is recorded
 FORCE_STATE_WRITE_INTERVAL = timedelta(minutes=5)
+
+
+def format_mac(mac: str) -> str:
+    """Format a MAC address string with colons.
+
+    Converts "CCBA97932A96" to "CC:BA:97:93:2A:96".
+    """
+    mac = mac.upper().replace(":", "").replace("-", "")
+    return ":".join(mac[i : i + 2] for i in range(0, 12, 2))
 
 
 async def async_setup_entry(
@@ -59,8 +69,6 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
     _last_state_write: datetime | None = None
     _last_availability: bool | None = None
     _last_charging_state: BatteryState | None = None
-    _pending_command: VacuumActivity | None = None
-    _command_sent_time: datetime | None = None
 
     def __init__(self, idx: str, coordinator: WyBotCoordinator) -> None:
         """Initialize the WyBot vacuum entity."""
@@ -72,8 +80,6 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
         self._last_state_write = None
         self._last_availability = None
         self._last_charging_state = None
-        self._pending_command = None
-        self._command_sent_time = None
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -102,60 +108,6 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
             and previous_charging_state != current_charging_state
         )
         self._last_charging_state = current_charging_state
-
-        # Clear pending command if we got a confirmed status that matches our expectation
-        if self._data and self._pending_command is not None:
-            cleaning_status = self._data.get_dp(CleaningStatus)
-            dock_status = self._data.get_dp(Dock)
-
-            # Check if we got a status that confirms our pending command
-            should_clear = False
-            if (
-                cleaning_status is not None
-                and cleaning_status.status != CleaningStatusMode.UNKNOWN
-            ):
-                # For CLEANING command, clear when we get CLEANING or STARTING status
-                if self._pending_command == VacuumActivity.CLEANING:
-                    if cleaning_status.status in (
-                        CleaningStatusMode.CLEANING,
-                        CleaningStatusMode.STARTING,
-                    ):
-                        should_clear = True
-                # For PAUSED command, clear when we get STOPPED status
-                elif self._pending_command == VacuumActivity.PAUSED:
-                    if cleaning_status.status == CleaningStatusMode.STOPPED:
-                        should_clear = True
-
-            # For RETURNING command, check dock status
-            if (
-                self._pending_command == VacuumActivity.RETURNING
-                and dock_status is not None
-            ):
-                # Clear if dock status shows RETURNING, or if we're now docked (charging)
-                battery = self._data.get_dp(Battery)
-                if dock_status.status == DockStatus.RETURNING or (
-                    battery is not None
-                    and battery.charge_state
-                    in (BatteryState.CHARGING, BatteryState.CHARGED)
-                ):
-                    should_clear = True
-
-            if should_clear:
-                _LOGGER.debug(
-                    "Clearing pending command %s for %s, got confirming status",
-                    self._pending_command,
-                    self.entity_id,
-                )
-                self._pending_command = None
-                self._command_sent_time = None
-            # Also clear if command is too old (more than 30 seconds)
-            elif (
-                self._command_sent_time is not None
-                and (dt_util.utcnow() - self._command_sent_time).total_seconds() > 30
-            ):
-                _LOGGER.debug("Clearing stale pending command for %s", self.entity_id)
-                self._pending_command = None
-                self._command_sent_time = None
 
         # Always write state if:
         # 1. Availability changed (to record unavailable/available transitions)
@@ -197,29 +149,47 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
         """Return if entity is available."""
         if not self.coordinator.available:
             return False
-        # Check coordinator data directly if local data not set
-        if not self._data and str(self._idx) in self.coordinator.data:
-            self._data = self.coordinator.data[str(self._idx)]
         if not self._data:
             return False
         if str(self._idx) not in self.coordinator.data:
             return False
+        # Check if device is online (received online: "1" from /will/ topic)
+        # Note: Device may show data even when offline if we have cached data
+        # We'll show available if we have data, but the device might be asleep
         return True
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
-        name = self._data.name if self._data else "Unknown"
-        model = (
-            self._data.device.device_type
-            if self._data and self._data.device
-            else "Unknown"
-        )
+        # Use group name, fall back to device name, then device type
+        name = "Unknown"
+        model = "Unknown"
+        connections: set[tuple[str, str]] = set()
+        via_device = None
+        if self._data:
+            if self._data.name:
+                name = self._data.name
+            elif self._data.device and self._data.device.device_name:
+                name = self._data.device.device_name
+            elif self._data.device and self._data.device.device_type:
+                name = self._data.device.device_type
+            if self._data.device:
+                model = self._data.device.device_type
+                # Add Bluetooth MAC connection if available
+                if self._data.device.ble_name:
+                    connections.add(
+                        (CONNECTION_BLUETOOTH, format_mac(self._data.device.ble_name))
+                    )
+            # If dock exists, robot connects via dock
+            if self._data.docker:
+                via_device = (DOMAIN, f"{self._idx}_dock")
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._idx))},
             name=name,
             manufacturer=MANUFACTURER,
             model=model,
+            connections=connections if connections else None,
+            via_device=via_device,
         )
 
     @property
@@ -237,100 +207,45 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
     @property
     def activity(self) -> VacuumActivity | None:
         """Return the state of the device."""
-        # Get data from coordinator if not set locally
-        if not self._data and str(self._idx) in self.coordinator.data:
-            self._data = self.coordinator.data[str(self._idx)]
-
         if not self._data:
             return None
         battery = self._data.get_dp(Battery)
         cleaning_status = self._data.get_dp(CleaningStatus)
         dock_status = self._data.get_dp(Dock)
+        dock_connection = self._data.get_dp(DockConnectionStatus)
 
-        # Require at least Battery and CleaningStatus to determine state
-        # Dock is optional (only needed for RETURNING detection)
-        if battery is None or cleaning_status is None:
-            return None
-
-        # If we have a pending command (optimistic state), prioritize it
-        # Use it if status is UNKNOWN, or if status doesn't match what we expect
-        if self._pending_command is not None:
-            # Always use pending command if status is UNKNOWN
-            if cleaning_status.status == CleaningStatusMode.UNKNOWN:
-                _LOGGER.debug(
-                    "Using pending command state %s for %s (status is UNKNOWN)",
-                    self._pending_command,
-                    self.entity_id,
-                )
-                return self._pending_command
-
-            # For RETURNING command, use it even if cleaning status is STOPPED
-            # (device might be stopped while returning to dock)
-            if self._pending_command == VacuumActivity.RETURNING:
-                _LOGGER.debug(
-                    "Using pending RETURNING state for %s (command in progress)",
-                    self.entity_id,
-                )
-                return self._pending_command
-
-            # For CLEANING command, only use if status is not CLEANING yet
-            if (
-                self._pending_command == VacuumActivity.CLEANING
-                and cleaning_status.status
-                not in (
-                    CleaningStatusMode.CLEANING,
-                    CleaningStatusMode.STARTING,
-                )
-            ):
-                _LOGGER.debug(
-                    "Using pending CLEANING state for %s (status: %s)",
-                    self.entity_id,
-                    cleaning_status.status,
-                )
-                return self._pending_command
-
-        # If device status is UNKNOWN, try to get status from docker as fallback
-        if (
-            cleaning_status.status == CleaningStatusMode.UNKNOWN
-            and self._data.docker is not None
+        # Check if returning to dock via CleaningStatus (DP 0) - primary indicator
+        if cleaning_status is not None and cleaning_status.status in (
+            CleaningStatusMode.RETURNING_TO_DOCK,
+            CleaningStatusMode.RETURNING,
         ):
-            docker_cleaning_status = self._data.docker.get_dp(CleaningStatus)
-            if (
-                docker_cleaning_status is not None
-                and docker_cleaning_status.status != CleaningStatusMode.UNKNOWN
-            ):
-                _LOGGER.debug(
-                    "Using docker cleaning status %s for %s (device status is UNKNOWN)",
-                    docker_cleaning_status.status,
-                    self.entity_id,
-                )
-                cleaning_status = docker_cleaning_status
+            return VacuumActivity.RETURNING
 
-        # Prioritize cleaning status over charging status
-        # If device is cleaning, show CLEANING even if charging
-        if cleaning_status.status in (
-            CleaningStatusMode.CLEANING,
-            CleaningStatusMode.STARTING,
-        ):
-            return VacuumActivity.CLEANING
-
-        # Check if returning to dock (only if dock status is available)
+        # Check if returning via Dock DP (fallback for legacy behavior)
         if dock_status is not None and dock_status.status == DockStatus.RETURNING:
             return VacuumActivity.RETURNING
 
-        # Check if charging/charged - device is docked
-        # This must come BEFORE the STOPPED check, because when docked the device
-        # reports STOPPED status but should show as DOCKED if charging
-        if battery.charge_state in (BatteryState.CHARGING, BatteryState.CHARGED):
+        # Check if docked - use dock status, dock connection status, or battery charging state
+        is_docked = False
+        if dock_status is not None and dock_status.status == DockStatus.DOCKED:
+            is_docked = True
+        elif dock_connection is not None:
+            is_docked = dock_connection.is_docked
+        elif battery is not None:
+            is_docked = battery.charge_state in (BatteryState.CHARGING, BatteryState.CHARGED)
+
+        if is_docked:
             return VacuumActivity.DOCKED
 
-        # Check if stopped/paused (only if not charging - handled above)
-        if cleaning_status.status == CleaningStatusMode.STOPPED:
-            return VacuumActivity.PAUSED
-
-        # Handle UNKNOWN status - assume idle/paused (charging already handled above)
-        if cleaning_status.status == CleaningStatusMode.UNKNOWN:
-            return VacuumActivity.PAUSED
+        # Check cleaning status
+        if cleaning_status is not None:
+            if cleaning_status.status in (
+                CleaningStatusMode.CLEANING,
+                CleaningStatusMode.STARTING,
+            ):
+                return VacuumActivity.CLEANING
+            if cleaning_status.status == CleaningStatusMode.STOPPED:
+                return VacuumActivity.PAUSED
 
         return None
 
@@ -342,10 +257,6 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
     @property
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
-        # Get data from coordinator if not set locally
-        if not self._data and str(self._idx) in self.coordinator.data:
-            self._data = self.coordinator.data[str(self._idx)]
-
         if not self._data:
             return None
         fan_speed = self._data.get_dp(CleaningMode)
@@ -368,38 +279,26 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
         if not self._data:
             return
         cleaning_mode = CleaningMode(mode=fan_speed)
-        self.coordinator.send_write_command(self._data, cleaning_mode)
+        await self.coordinator.async_send_command(self._data, cleaning_mode)
 
     async def async_stop(self) -> None:
         """Stop the vacuum cleaner."""
         if not self._data:
             return
-        cleaning_mode = CleaningStatus(status=CleaningStatusMode.STOPPED)
-        self.coordinator.send_write_command(self._data, cleaning_mode)
-        # Set optimistic state - show as paused until we get confirmation
-        self._pending_command = VacuumActivity.PAUSED
-        self._command_sent_time = dt_util.utcnow()
-        self.async_write_ha_state()
+        cleaning_status = CleaningStatus(status=CleaningStatusMode.STOPPED)
+        await self.coordinator.async_send_command(self._data, cleaning_status)
 
     async def async_start(self) -> None:
         """Start the vacuum cleaner."""
         if not self._data:
             return
-        cleaning_mode = CleaningStatus(status=CleaningStatusMode.CLEANING)
-        self.coordinator.send_write_command(self._data, cleaning_mode)
-        # Set optimistic state - show as cleaning until we get confirmation
-        self._pending_command = VacuumActivity.CLEANING
-        self._command_sent_time = dt_util.utcnow()
-        self.async_write_ha_state()
+        cleaning_status = CleaningStatus(status=CleaningStatusMode.CLEANING)
+        await self.coordinator.async_send_command(self._data, cleaning_status)
 
     async def async_return_to_base(self) -> None:
         """Return the vacuum cleaner to the dock."""
         if not self._data:
             return
-        self.coordinator.send_write_command(
+        await self.coordinator.async_send_command(
             self._data, Dock(status=DockStatus.RETURNING)
         )
-        # Set optimistic state - show as returning until we get confirmation
-        self._pending_command = VacuumActivity.RETURNING
-        self._command_sent_time = dt_util.utcnow()
-        self.async_write_ha_state()

--- a/custom_components/wybot/wybot_ble_client.py
+++ b/custom_components/wybot/wybot_ble_client.py
@@ -1,0 +1,1403 @@
+"""BLE client for waking up WyBot devices using Home Assistant Bluetooth."""
+
+import asyncio
+import logging
+from typing import Any
+
+from bleak import BleakClient, BleakError
+from bleak.backends.device import BLEDevice
+from bleak_retry_connector import establish_connection
+
+from homeassistant.components.bluetooth import (
+    async_ble_device_from_address,
+    async_discovered_service_info,
+    async_scanner_count,
+)
+from homeassistant.core import HomeAssistant
+
+from .const import BLE_COMMAND_HOLD_TIME, BLE_COMMAND_TIMEOUT
+from .wybot_dp_models import GenericDP
+
+_LOGGER = logging.getLogger(__name__)
+
+# =============================================================================
+# BLE Service and Characteristic UUIDs
+# =============================================================================
+# DS20 Solar Dock actual UUIDs (discovered via BLE scan):
+# - Service 000000ee has characteristic 0000ee01 (read/write/notify)
+# - Service 000000ff has characteristic 0000ff01 (read/write/notify)
+#
+# APK K1 series UUIDs (from k1/AbstractC0300a.java) - different device model:
+# - Service 00001000 with characteristics 00001001-00001005
+# =============================================================================
+
+# DS20 Solar Dock Service UUIDs (ACTUAL - verified via BLE scan)
+SERVICE_UUID_EE = "000000ee-0000-1000-8000-00805f9b34fb"
+SERVICE_UUID_FF = "000000ff-0000-1000-8000-00805f9b34fb"
+
+# DS20 Solar Dock Characteristic UUIDs
+CHAR_UUID_EE01 = "0000ee01-0000-1000-8000-00805f9b34fb"  # read/write/notify
+CHAR_UUID_FF01 = "0000ff01-0000-1000-8000-00805f9b34fb"  # read/write/notify
+
+# K1 series UUIDs (from APK - may be used by different models)
+SERVICE_UUID_K1 = "00001000-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_1001 = "00001001-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_1002 = "00001002-0000-1000-8000-00805f9b34fb"  # Notifications/Data
+
+# Notification descriptor UUID (CCCD)
+CCCD_UUID = "00002902-0000-1000-8000-00805f9b34fb"
+
+# All known WyBot service UUIDs for matching
+KNOWN_SERVICE_UUIDS = [
+    SERVICE_UUID_EE.lower(),
+    SERVICE_UUID_FF.lower(),
+    SERVICE_UUID_K1.lower(),
+]
+
+# Connection timeout (APK uses 3000ms, we use longer for reliability)
+CONNECTION_TIMEOUT = 15.0
+
+# Wake hold time - how long to maintain connection for device to fully wake
+WAKE_HOLD_TIME = 5.0
+
+# WiFi configuration hold time - allow device to process WiFi config
+WIFI_CONFIG_HOLD_TIME = 3.0
+
+# =============================================================================
+# Wake Commands - various patterns to try to wake the device
+# =============================================================================
+# Simple wake byte
+WAKE_CMD_SIMPLE = bytes([0x01])
+
+# Tuya-style header with query command (cmd=9)
+WAKE_CMD_TUYA_QUERY = bytes([0x55, 0xAA, 0x00, 0x09, 0x00, 0x00, 0x09])
+
+# Tuya-style header with status request (cmd=0)
+WAKE_CMD_TUYA_STATUS = bytes([0x55, 0xAA, 0x00, 0x00, 0x00, 0x00, 0x00])
+
+# Generic ping/wake patterns
+WAKE_CMD_PING = bytes([0x00])
+WAKE_CMD_FF = bytes([0xFF])
+
+# =============================================================================
+# Binary AA55 Format Commands (Verified working via PacketLogger capture Jan 2026)
+# =============================================================================
+# The WyBot app uses binary format sent to EE01 characteristic, NOT JSON!
+
+# Pre-built binary commands
+CMD_START_CLEANING = bytes.fromhex("aa5500040400000401030f")  # DP 0 = 03
+CMD_STOP_CLEANING = bytes.fromhex("aa5500040400000401010d")  # DP 0 = 01
+CMD_RETURN_TO_DOCK = bytes.fromhex("aa55000404000b04010118")  # DP 11 = 01
+
+# Cleaning mode commands (DP 1)
+CMD_MODE_FLOOR = bytes.fromhex("aa5500040400010401000d")  # Mode 00
+CMD_MODE_WALL = bytes.fromhex("aa5500040400010401010e")  # Mode 01
+CMD_MODE_WALL_THEN_FLOOR = bytes.fromhex("aa5500040400010401020f")  # Mode 02
+CMD_MODE_ADVANCED_FULL = bytes.fromhex("aa55000404000104010310")  # Mode 03
+CMD_MODE_WATER_LINE = bytes.fromhex("aa55000404000104010411")  # Mode 04
+CMD_MODE_TURBO_FLOOR = bytes.fromhex("aa55000404000104010512")  # Mode 05
+CMD_MODE_ECO_FLOOR = bytes.fromhex("aa55000404000104010613")  # Mode 06
+
+# WiFi configuration commands
+CMD_WIFI_INIT = bytes.fromhex("aa55002d020000002e")  # WiFi init/reset
+CMD_WIFI_APPLY = bytes.fromhex("aa550003000002")  # Apply configuration
+
+# Query command (binary format)
+CMD_QUERY_STATUS = bytes.fromhex("aa5500090000000a")  # cmd=9, no payload
+
+
+class WyBotBLEClient:
+    """BLE client for waking up WyBot devices using HA Bluetooth integration.
+
+    Based on APK analysis of WyBot app (k1/AbstractC0300a.java):
+    - Device wakes when BLE connection is established (onConnectionStateChange state=2)
+    - After wake, device auto-connects to MQTT broker
+    - No special wake command byte needed - connection itself triggers wake
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the BLE client.
+
+        Args:
+            hass: Home Assistant instance for accessing Bluetooth integration
+        """
+        self._hass = hass
+        self._wake_in_progress: bool = False
+        self._last_notification_data: bytes | None = None
+        self._last_status_data: bytes | None = None  # Status broadcasts (cmd=0x05)
+
+    def _build_binary_command(
+        self, cmd: int, dp_id: int, dp_type: int, dp_len: int, dp_value: bytes
+    ) -> bytes:
+        """Build binary AA55 format command for BLE.
+
+        The WyBot app uses binary format sent to EE01 characteristic.
+        Format: AA55 + cmd(2, big) + len(2, little) + dp_data + checksum(1)
+
+        Args:
+            cmd: Command type (4=write, 9=query)
+            dp_id: Data point ID
+            dp_type: Data point type (0=raw, 2=32-bit, 4=enum, 5=string)
+            dp_len: Length of dp_value
+            dp_value: The value bytes
+
+        Returns:
+            Complete binary command with checksum
+        """
+        dp_data = bytes([dp_id, dp_type, dp_len]) + dp_value
+        header = b"\xaa\x55"
+        cmd_bytes = cmd.to_bytes(2, "big")
+        payload_len = len(dp_data).to_bytes(2, "little")  # Little endian per protocol
+        packet = header + cmd_bytes + payload_len + dp_data
+        checksum = (sum(packet[2:]) - 1) & 0xFF  # Subtract 1 per protocol
+        return packet + bytes([checksum])
+
+    def _build_binary_query(self, dp_id: int) -> bytes:
+        """Build a binary query command for a single DP.
+
+        Format: aa55 + 0009 + len_le + dp_id + checksum
+
+        Args:
+            dp_id: The DP ID to query (e.g., 1 for CleaningMode)
+
+        Returns:
+            Binary command bytes ready to send to EE01
+
+        Example:
+            _build_binary_query(1) -> aa5500090100010a (query CleaningMode)
+        """
+        header = b"\xaa\x55"
+        cmd = b"\x00\x09"  # Query command
+        length = (1).to_bytes(2, "little")  # 1 byte payload, little-endian
+        payload = bytes([dp_id])
+        packet = header + cmd + length + payload
+        checksum = (sum(packet[2:]) - 1) & 0xFF  # Subtract 1 per protocol
+        return packet + bytes([checksum])
+
+    def _build_wifi_ssid_command(self, ssid: str) -> bytes:
+        """Build WiFi SSID command (cmd=0x2A).
+
+        Args:
+            ssid: WiFi network name
+
+        Returns:
+            Binary command for sending SSID
+        """
+        ssid_bytes = ssid.encode("utf-8")
+        # Pad SSID to fixed length (observed ~34 bytes in captures)
+        padded_ssid = ssid_bytes.ljust(34, b"\x00")
+        header = b"\xaa\x55"
+        cmd_bytes = (0x2A).to_bytes(2, "big")
+        payload_len = len(padded_ssid).to_bytes(2, "big")
+        packet = header + cmd_bytes + payload_len + padded_ssid
+        checksum = sum(packet[2:]) & 0xFF
+        return packet + bytes([checksum])
+
+    def _build_wifi_password_command(self, password: str) -> bytes:
+        """Build WiFi password command (cmd=0x2B).
+
+        Args:
+            password: WiFi password
+
+        Returns:
+            Binary command for sending password
+        """
+        password_bytes = password.encode("utf-8")
+        header = b"\xaa\x55"
+        cmd_bytes = (0x2B).to_bytes(2, "big")
+        payload_len = len(password_bytes).to_bytes(2, "big")
+        packet = header + cmd_bytes + payload_len + password_bytes
+        checksum = sum(packet[2:]) & 0xFF
+        return packet + bytes([checksum])
+
+    def _is_bluetooth_available(self) -> bool:
+        """Check if Bluetooth is available (local or proxy)."""
+        try:
+            count = async_scanner_count(self._hass, connectable=True)
+            _LOGGER.debug("Bluetooth scanner count: %d", count)
+            return count > 0
+        except Exception as err:
+            _LOGGER.debug("Error checking Bluetooth availability: %s", err)
+            return False
+
+    def _notification_handler(self, sender: Any, data: bytearray) -> None:
+        """Handle BLE notifications from device.
+
+        Args:
+            sender: The characteristic that sent the notification (BleakGATTCharacteristic or int)
+            data: The notification data
+        """
+        data_bytes = bytes(data)
+        self._last_notification_data = data_bytes
+
+        # Store status broadcasts (cmd=0x05) separately so ACKs don't overwrite them
+        if len(data_bytes) >= 4 and data_bytes[:2] == b"\xaa\x55" and data_bytes[3] == 0x05:
+            self._last_status_data = data_bytes
+            _LOGGER.info(
+                "Received BLE STATUS broadcast (cmd=05): %s (%d bytes)",
+                data_bytes.hex(),
+                len(data_bytes),
+            )
+        else:
+            # sender can be BleakGATTCharacteristic object or int depending on backend
+            sender_str = str(getattr(sender, "uuid", sender))
+            _LOGGER.info(
+                "Received BLE notification from %s: %s (%d bytes)",
+                sender_str,
+                data_bytes.hex() if data_bytes else "empty",
+                len(data_bytes) if data_bytes else 0,
+            )
+
+    async def _log_device_services(self, client: BleakClient) -> dict[str, Any]:
+        """Log all services and characteristics for debugging.
+
+        Args:
+            client: Connected BleakClient
+
+        Returns:
+            Dict with service discovery information
+        """
+        discovery_info = {
+            "services": [],
+            "found_primary_service": False,
+            "found_notification_char": False,
+        }
+
+        _LOGGER.info("=== BLE Service Discovery ===")
+        for service in client.services:
+            service_uuid = str(service.uuid).lower()
+            is_known = service_uuid in KNOWN_SERVICE_UUIDS
+
+            service_info = {
+                "uuid": service_uuid,
+                "is_wybot_service": is_known,
+                "characteristics": [],
+            }
+
+            if is_known:
+                _LOGGER.info("✓ Found WyBot service: %s", service.uuid)
+                discovery_info["found_primary_service"] = True
+            else:
+                _LOGGER.debug("  Service: %s", service.uuid)
+
+            for char in service.characteristics:
+                char_uuid = str(char.uuid).lower()
+                char_info = {
+                    "uuid": char_uuid,
+                    "properties": list(char.properties),
+                }
+                service_info["characteristics"].append(char_info)
+
+                # Check for notification characteristic
+                is_notify_char = "1002" in char_uuid or char_uuid == CHAR_UUID_1002.lower()
+                if is_notify_char and "notify" in char.properties:
+                    discovery_info["found_notification_char"] = True
+                    _LOGGER.info(
+                        "  ✓ Notification char: %s (properties: %s)",
+                        char.uuid,
+                        char.properties,
+                    )
+                elif is_known:
+                    _LOGGER.info(
+                        "    Char: %s (properties: %s)", char.uuid, char.properties
+                    )
+                else:
+                    _LOGGER.debug(
+                        "    Char: %s (properties: %s)", char.uuid, char.properties
+                    )
+
+            discovery_info["services"].append(service_info)
+
+        _LOGGER.info("=== End Service Discovery ===")
+        return discovery_info
+
+    async def _enable_notifications(self, client: BleakClient) -> bool:
+        """Enable notifications on the data characteristic.
+
+        DS20 devices receive notifications on FF01 (verified via PacketLogger).
+        K1 devices use 1002 characteristic.
+        Note: EE01 is for writing commands only, not notifications.
+
+        Args:
+            client: Connected BleakClient
+
+        Returns:
+            True if notifications were enabled successfully
+        """
+        # Priority order for notification characteristics
+        # FF01 is the correct notification characteristic for DS20 (verified)
+        target_chars = [
+            CHAR_UUID_FF01.lower(),  # DS20 notifications (verified correct)
+            CHAR_UUID_1002.lower(),  # K1 series
+        ]
+
+        for service in client.services:
+            service_uuid = str(service.uuid).lower()
+
+            # Only check WyBot services
+            if service_uuid not in KNOWN_SERVICE_UUIDS:
+                continue
+
+            for char in service.characteristics:
+                char_uuid = str(char.uuid).lower()
+
+                # Check if this is a target notification characteristic
+                is_target = char_uuid in target_chars or (
+                    service_uuid in KNOWN_SERVICE_UUIDS and "notify" in char.properties
+                )
+
+                if is_target and "notify" in char.properties:
+                    try:
+                        _LOGGER.info(
+                            "Enabling notifications on %s (service: %s)",
+                            char.uuid,
+                            service.uuid,
+                        )
+                        await client.start_notify(char.uuid, self._notification_handler)
+                        _LOGGER.info("✓ Notifications enabled successfully")
+                        return True
+                    except Exception as err:
+                        _LOGGER.warning(
+                            "Failed to enable notifications on %s: %s",
+                            char.uuid,
+                            err,
+                        )
+
+        _LOGGER.debug("No suitable notification characteristic found")
+        return False
+
+    async def _write_binary_command_to_ee01(
+        self, client: BleakClient, command: bytes
+    ) -> bool:
+        """Write a binary command to the EE01 characteristic.
+
+        The WyBot app only writes commands to EE01 (verified via PacketLogger).
+        Commands written to FF01 are ignored.
+
+        Args:
+            client: Connected BleakClient
+            command: Binary command bytes to write
+
+        Returns:
+            True if write succeeded
+        """
+        target_char = CHAR_UUID_EE01.lower()
+
+        for service in client.services:
+            service_uuid = str(service.uuid).lower()
+
+            # Only write to WyBot EE service
+            if service_uuid != SERVICE_UUID_EE.lower():
+                continue
+
+            for char in service.characteristics:
+                char_uuid = str(char.uuid).lower()
+
+                if char_uuid == target_char:
+                    can_write = (
+                        "write" in char.properties
+                        or "write-without-response" in char.properties
+                    )
+                    if can_write:
+                        use_response = "write" in char.properties
+                        try:
+                            _LOGGER.info(
+                                "BLE write to EE01 (%d bytes): %s",
+                                len(command),
+                                command.hex(),
+                            )
+                            await client.write_gatt_char(
+                                char.uuid,
+                                command,
+                                response=use_response,
+                            )
+                            _LOGGER.info("✓ BLE write to EE01 succeeded")
+                            return True
+                        except (BleakError, OSError) as err:
+                            _LOGGER.warning("BLE write to EE01 failed: %s", err)
+                            return False
+
+        _LOGGER.warning("EE01 characteristic not found for writing")
+        return False
+
+    async def _write_wake_commands(self, client: BleakClient) -> bool:
+        """Write wake commands to writable characteristics.
+
+        Tries multiple wake command patterns on the EE01 characteristic
+        to trigger the device to wake up and connect to MQTT.
+
+        Args:
+            client: Connected BleakClient
+
+        Returns:
+            True if at least one write succeeded
+        """
+        wake_commands = [
+            ("simple 0x01", WAKE_CMD_SIMPLE),
+            ("Tuya query", WAKE_CMD_TUYA_QUERY),
+            ("Tuya status", WAKE_CMD_TUYA_STATUS),
+            ("ping 0x00", WAKE_CMD_PING),
+        ]
+
+        # Only write to EE01 - verified as the correct write characteristic
+        target_chars = [
+            CHAR_UUID_EE01.lower(),  # DS20 write characteristic (verified)
+        ]
+
+        any_write_succeeded = False
+
+        for service in client.services:
+            service_uuid = str(service.uuid).lower()
+
+            # Only write to WyBot services
+            if service_uuid not in KNOWN_SERVICE_UUIDS:
+                continue
+
+            for char in service.characteristics:
+                char_uuid = str(char.uuid).lower()
+
+                # Check if this characteristic is writable
+                can_write = "write" in char.properties or "write-without-response" in char.properties
+                is_target = char_uuid in target_chars
+
+                if is_target and can_write:
+                    use_response = "write" in char.properties
+
+                    for cmd_name, cmd_bytes in wake_commands:
+                        try:
+                            _LOGGER.info(
+                                "Writing wake command '%s' (%s) to %s",
+                                cmd_name,
+                                cmd_bytes.hex(),
+                                char.uuid,
+                            )
+                            await client.write_gatt_char(
+                                char.uuid,
+                                cmd_bytes,
+                                response=use_response,
+                            )
+                            _LOGGER.info(
+                                "✓ Wake command '%s' written successfully to %s",
+                                cmd_name,
+                                char.uuid,
+                            )
+                            any_write_succeeded = True
+
+                            # Small delay between commands
+                            await asyncio.sleep(0.5)
+
+                        except Exception as err:
+                            _LOGGER.debug(
+                                "Failed to write '%s' to %s: %s",
+                                cmd_name,
+                                char.uuid,
+                                err,
+                            )
+
+        if not any_write_succeeded:
+            _LOGGER.warning("No wake commands could be written to any characteristic")
+
+        return any_write_succeeded
+
+    async def scan_for_device(self, ble_name: str) -> BLEDevice | None:
+        """Scan for a WyBot device by its BLE name using HA Bluetooth.
+
+        This uses Home Assistant's Bluetooth integration which supports:
+        - Local Bluetooth adapters
+        - ESPHome Bluetooth proxies
+        - Shelly BLE proxies
+
+        Args:
+            ble_name: The BLE advertisement name (usually MAC address like CCBA97932A96)
+
+        Returns:
+            The BLEDevice if found, None otherwise
+        """
+        if not self._is_bluetooth_available():
+            _LOGGER.warning("No Bluetooth adapters or proxies available")
+            return None
+
+        _LOGGER.debug("Scanning for WyBot device with BLE name: %s", ble_name)
+
+        # Get all discovered devices from HA Bluetooth
+        try:
+            service_infos = async_discovered_service_info(self._hass, connectable=True)
+            _LOGGER.debug("Found %d BLE devices in scan", len(service_infos))
+
+            for service_info in service_infos:
+                device = service_info.device
+                _LOGGER.debug(
+                    "Checking BLE device: name=%s, address=%s",
+                    device.name,
+                    device.address,
+                )
+
+                # Check if device name matches (could be in name or address)
+                if device.name and ble_name.upper() in device.name.upper():
+                    _LOGGER.info(
+                        "Found WyBot device: %s at %s", device.name, device.address
+                    )
+                    return device
+
+                # Also check if ble_name matches the MAC address format
+                # ble_name is like "CCBA97932A96", address is like "CC:BA:97:93:2A:96"
+                clean_ble_name = ble_name.upper().replace(":", "")
+                clean_address = device.address.upper().replace(":", "")
+                if clean_ble_name in clean_address or clean_address in clean_ble_name:
+                    _LOGGER.info(
+                        "Found WyBot device by MAC: %s at %s",
+                        device.name,
+                        device.address,
+                    )
+                    return device
+
+        except Exception as err:
+            _LOGGER.warning("Error during BLE scan: %s", err)
+
+        _LOGGER.debug("WyBot device with BLE name %s not found", ble_name)
+        return None
+
+    async def wake_device(self, ble_name: str) -> bool:
+        """Wake up a WyBot device by establishing a BLE connection.
+
+        Based on APK analysis: The device wakes when BLE connection is established.
+        The onConnectionStateChange callback with state=2 (connected) triggers wake.
+        After waking, the device automatically connects to the MQTT broker.
+
+        Sequence (matching APK behavior):
+        1. Scan for device by BLE name (or use MAC directly if scan fails)
+        2. Connect to device (this triggers wake via state change)
+        3. Discover services (validates connection)
+        4. Enable notifications on 1002 characteristic (mimics app)
+        5. Hold connection for device to fully wake
+        6. Disconnect gracefully - device should now connect to MQTT
+
+        Args:
+            ble_name: The BLE advertisement name (usually MAC address like CCBA97932A96)
+
+        Returns:
+            True if wake was successful, False otherwise
+        """
+        if self._wake_in_progress:
+            _LOGGER.debug("Wake already in progress, skipping")
+            return False
+
+        self._wake_in_progress = True
+        self._last_notification_data = None
+
+        try:
+            # Step 1: Try to scan for the device first
+            device = await self.scan_for_device(ble_name)
+
+            # If scan didn't find it, try using the BLE name as MAC address directly
+            # WyBot BLE names are typically MAC addresses without colons
+            if not device:
+                _LOGGER.info(
+                    "Device %s not found in scan, trying direct MAC connection", ble_name
+                )
+                # Convert BLE name to MAC format (e.g., "3C8427565A1A" -> "3C:84:27:56:5A:1A")
+                if len(ble_name) == 12 and all(c in '0123456789ABCDEFabcdef' for c in ble_name):
+                    mac_address = ':'.join(ble_name[i:i+2] for i in range(0, 12, 2)).upper()
+                    _LOGGER.info("Converted BLE name to MAC: %s", mac_address)
+                else:
+                    mac_address = ble_name
+
+                # Try to get device from HA's bluetooth by address
+                ble_device = async_ble_device_from_address(
+                    self._hass, mac_address, connectable=True
+                )
+                if ble_device:
+                    _LOGGER.info(
+                        "Found device via direct MAC lookup: %s", mac_address
+                    )
+                    # Create a simple device-like object for the rest of the flow
+                    class DirectDevice:
+                        def __init__(self, addr):
+                            self.address = addr
+                            self.name = f"WyBot-{addr}"
+                    device = DirectDevice(mac_address)
+                else:
+                    _LOGGER.warning(
+                        "Could not find WyBot device %s via scan or direct MAC", ble_name
+                    )
+                    return False
+
+            _LOGGER.info(
+                "Found WyBot device, initiating wake connection to %s (%s)",
+                getattr(device, 'name', 'Unknown'),
+                device.address,
+            )
+
+            try:
+                # Get BLE device through HA's bluetooth module (supports proxies)
+                ble_device = async_ble_device_from_address(
+                    self._hass, device.address, connectable=True
+                )
+
+                if not ble_device:
+                    _LOGGER.warning(
+                        "Could not get BLE device for address %s", device.address
+                    )
+                    return False
+
+                # Step 2: Connect to device using bleak_retry_connector
+                # This properly handles ESPHome proxy connections
+                # According to APK, device wakes on onConnectionStateChange state=2
+                _LOGGER.info("Establishing BLE connection via bleak_retry_connector...")
+                client = await establish_connection(
+                    BleakClient,
+                    ble_device,
+                    ble_device.name or ble_device.address,
+                    max_attempts=3,
+                )
+
+                try:
+                    if not client.is_connected:
+                        _LOGGER.warning("Failed to establish BLE connection")
+                        return False
+
+                    _LOGGER.info(
+                        "✓ Connected to WyBot device - device should be waking"
+                    )
+
+                    # Step 3: Discover and log services (for debugging)
+                    discovery_info = await self._log_device_services(client)
+
+                    if discovery_info["found_primary_service"]:
+                        _LOGGER.info(
+                            "✓ Found expected WyBot BLE service (00001000)"
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "⚠ Primary WyBot service (00001000) not found - "
+                            "device may use different UUIDs. Check logs above."
+                        )
+
+                    # Step 4: Enable notifications (mimics APK behavior)
+                    notifications_enabled = await self._enable_notifications(client)
+                    if notifications_enabled:
+                        _LOGGER.info("✓ Notifications enabled on data characteristic")
+                    else:
+                        _LOGGER.debug(
+                            "Could not enable notifications - wake may still work"
+                        )
+
+                    # Step 5: Write wake commands to characteristics
+                    _LOGGER.info("Writing wake commands to trigger device...")
+                    wake_written = await self._write_wake_commands(client)
+                    if wake_written:
+                        _LOGGER.info("✓ Wake commands written to characteristics")
+                    else:
+                        _LOGGER.warning(
+                            "Could not write wake commands - connection alone may wake device"
+                        )
+
+                    # Step 6: Hold connection for device to fully wake
+                    # APK uses 3000ms timeout, we use longer for reliability
+                    _LOGGER.info(
+                        "Holding connection for %.1fs to allow device to wake...",
+                        WAKE_HOLD_TIME,
+                    )
+                    await asyncio.sleep(WAKE_HOLD_TIME)
+
+                    # Check if we received any notification data
+                    if self._last_notification_data:
+                        _LOGGER.info(
+                            "✓ Received notification data during wake: %s",
+                            self._last_notification_data.hex(),
+                        )
+
+                    # Step 7: Disconnect gracefully
+                    _LOGGER.info(
+                        "✓ Wake sequence complete for %s - device should connect to MQTT",
+                        ble_name,
+                    )
+                    return True
+
+                finally:
+                    # Always disconnect
+                    if client.is_connected:
+                        await client.disconnect()
+
+            except asyncio.TimeoutError:
+                # Timeout may still result in device wake - the BLE connection
+                # ATTEMPT itself triggers wake (per APK analysis: onConnectionStateChange)
+                _LOGGER.info(
+                    "BLE connection timed out for %s - device may still wake from the attempt",
+                    device.address,
+                )
+                # Return True since connection attempt was made (may have woken device)
+                return True
+            except BleakError as err:
+                err_str = str(err)
+                # Timeout errors during connection still trigger device wake
+                if "timeout" in err_str.lower() or "Timeout" in err_str:
+                    _LOGGER.info(
+                        "BLE connection timeout for %s: %s - device may still wake",
+                        device.address,
+                        err,
+                    )
+                    # Return True since connection attempt was made
+                    return True
+                _LOGGER.warning("BLE connection error: %s", err)
+                return False
+
+        except Exception as err:
+            _LOGGER.error("Unexpected error during BLE wake: %s", err)
+            return False
+        finally:
+            self._wake_in_progress = False
+
+    async def wake_devices(self, ble_names: list[str]) -> dict[str, bool]:
+        """Wake up multiple WyBot devices.
+
+        Args:
+            ble_names: List of BLE names to wake
+
+        Returns:
+            Dict mapping BLE name to wake success status
+        """
+        results = {}
+        for ble_name in ble_names:
+            results[ble_name] = await self.wake_device(ble_name)
+            # Small delay between wake attempts
+            await asyncio.sleep(1.0)
+        return results
+
+    async def _write_wifi_config(
+        self, client: BleakClient, ssid: str, password: str
+    ) -> bool:
+        """Write WiFi configuration using binary AA55 format to EE01.
+
+        Sends the documented WiFi configuration sequence:
+        1. WiFi init (cmd=0x2D)
+        2. Send SSID (cmd=0x2A)
+        3. Send password (cmd=0x2B)
+        4. Apply config (cmd=0x03)
+
+        Args:
+            client: Connected BleakClient
+            ssid: WiFi network name
+            password: WiFi password
+
+        Returns:
+            True if all writes succeeded
+        """
+        _LOGGER.info("Sending WiFi configuration via binary protocol")
+
+        # Step 1: WiFi init/reset
+        _LOGGER.info("Step 1: WiFi init (cmd=0x2D)")
+        if not await self._write_binary_command_to_ee01(client, CMD_WIFI_INIT):
+            _LOGGER.warning("WiFi init command failed")
+            return False
+        await asyncio.sleep(0.5)
+
+        # Step 2: Send SSID
+        ssid_cmd = self._build_wifi_ssid_command(ssid)
+        _LOGGER.info("Step 2: Send SSID (cmd=0x2A): %s", ssid)
+        if not await self._write_binary_command_to_ee01(client, ssid_cmd):
+            _LOGGER.warning("WiFi SSID command failed")
+            return False
+        await asyncio.sleep(0.5)
+
+        # Step 3: Send password
+        password_cmd = self._build_wifi_password_command(password)
+        _LOGGER.info("Step 3: Send password (cmd=0x2B)")
+        if not await self._write_binary_command_to_ee01(client, password_cmd):
+            _LOGGER.warning("WiFi password command failed")
+            return False
+        await asyncio.sleep(0.5)
+
+        # Step 4: Apply configuration
+        _LOGGER.info("Step 4: Apply WiFi config (cmd=0x03)")
+        if not await self._write_binary_command_to_ee01(client, CMD_WIFI_APPLY):
+            _LOGGER.warning("WiFi apply command failed")
+            return False
+
+        _LOGGER.info("✓ WiFi configuration sequence complete")
+        return True
+
+    # Legacy method removed - was _build_wifi_config_payloads with guessed encodings
+    # Now using documented binary AA55 format in _write_wifi_config
+
+    async def configure_wifi(self, ble_name: str, ssid: str, password: str) -> bool:
+        """Configure WiFi credentials on a WyBot device via BLE.
+
+        This method connects to the device and sends WiFi configuration
+        using the documented binary AA55 protocol.
+
+        Args:
+            ble_name: The BLE advertisement name (usually MAC address like CCBA97932A96)
+            ssid: WiFi network name to configure
+            password: WiFi password
+
+        Returns:
+            True if WiFi configuration was sent successfully, False otherwise
+        """
+        if self._wake_in_progress:
+            _LOGGER.debug("Wake/config already in progress, skipping WiFi config")
+            return False
+
+        self._wake_in_progress = True
+        self._last_notification_data = None
+
+        try:
+            _LOGGER.info(
+                "Attempting WiFi configuration for device %s (SSID: %s)",
+                ble_name,
+                ssid,
+            )
+
+            # Step 1: Find the device
+            device = await self.scan_for_device(ble_name)
+
+            if not device:
+                _LOGGER.info(
+                    "Device %s not found in scan, trying direct MAC connection",
+                    ble_name,
+                )
+                # Convert BLE name to MAC format
+                if len(ble_name) == 12 and all(
+                    c in "0123456789ABCDEFabcdef" for c in ble_name
+                ):
+                    mac_address = ":".join(
+                        ble_name[i : i + 2] for i in range(0, 12, 2)
+                    ).upper()
+                    _LOGGER.info("Converted BLE name to MAC: %s", mac_address)
+                else:
+                    mac_address = ble_name
+
+                ble_device = async_ble_device_from_address(
+                    self._hass, mac_address, connectable=True
+                )
+                if ble_device:
+                    _LOGGER.info("Found device via direct MAC lookup: %s", mac_address)
+
+                    class DirectDevice:
+                        def __init__(self, addr: str) -> None:
+                            self.address = addr
+                            self.name = f"WyBot-{addr}"
+
+                    device = DirectDevice(mac_address)
+                else:
+                    _LOGGER.warning(
+                        "Could not find WyBot device %s for WiFi configuration",
+                        ble_name,
+                    )
+                    return False
+
+            _LOGGER.info(
+                "Found WyBot device, initiating WiFi configuration for %s (%s)",
+                getattr(device, "name", "Unknown"),
+                device.address,
+            )
+
+            try:
+                # Get BLE device through HA's bluetooth module
+                ble_device = async_ble_device_from_address(
+                    self._hass, device.address, connectable=True
+                )
+
+                if not ble_device:
+                    _LOGGER.warning(
+                        "Could not get BLE device for address %s", device.address
+                    )
+                    return False
+
+                # Step 2: Connect to device
+                _LOGGER.info("Establishing BLE connection for WiFi configuration...")
+                client = await establish_connection(
+                    BleakClient,
+                    ble_device,
+                    ble_device.name or ble_device.address,
+                    max_attempts=3,
+                )
+
+                try:
+                    if not client.is_connected:
+                        _LOGGER.warning("Failed to establish BLE connection")
+                        return False
+
+                    _LOGGER.info("✓ Connected to WyBot device for WiFi configuration")
+
+                    # Step 3: Discover services
+                    await self._log_device_services(client)
+
+                    # Step 4: Enable notifications to receive any response
+                    await self._enable_notifications(client)
+
+                    # Step 5: Write WiFi configuration
+                    _LOGGER.info("Sending WiFi configuration to device...")
+                    config_written = await self._write_wifi_config(
+                        client, ssid, password
+                    )
+
+                    if config_written:
+                        _LOGGER.info("✓ WiFi configuration sent to device")
+                    else:
+                        _LOGGER.warning("Could not write WiFi configuration")
+
+                    # Step 6: Hold connection to allow device to process
+                    _LOGGER.info(
+                        "Holding connection for %.1fs for device to process WiFi config...",
+                        WIFI_CONFIG_HOLD_TIME,
+                    )
+                    await asyncio.sleep(WIFI_CONFIG_HOLD_TIME)
+
+                    # Check for any notification response
+                    if self._last_notification_data:
+                        _LOGGER.info(
+                            "Received notification after WiFi config: %s",
+                            self._last_notification_data.hex(),
+                        )
+
+                    _LOGGER.info(
+                        "✓ WiFi configuration complete for %s - device should reconnect",
+                        ble_name,
+                    )
+                    return config_written
+
+                finally:
+                    if client.is_connected:
+                        await client.disconnect()
+
+            except TimeoutError:
+                _LOGGER.warning(
+                    "BLE connection timed out during WiFi configuration for %s",
+                    ble_name,
+                )
+                return False
+            except BleakError as err:
+                _LOGGER.warning("BLE error during WiFi configuration: %s", err)
+                return False
+
+        except (BleakError, OSError) as err:
+            _LOGGER.error("Unexpected error during WiFi configuration: %s", err)
+            return False
+        finally:
+            self._wake_in_progress = False
+
+    def _build_command_payload_binary(self, dp: GenericDP) -> bytes:
+        """Build command payload using binary AA55 format.
+
+        The WyBot app uses binary format for BLE commands (verified via PacketLogger).
+        Format: AA55 + cmd(2) + len(2) + dp_data + checksum(1)
+
+        Args:
+            dp: The GenericDP data point to send
+
+        Returns:
+            Binary command payload
+        """
+        # Convert hex data string to bytes
+        dp_value = bytes.fromhex(dp.data) if dp.data else b""
+        return self._build_binary_command(
+            cmd=4,  # Write command
+            dp_id=dp.id,
+            dp_type=dp.type,
+            dp_len=dp.len,
+            dp_value=dp_value,
+        )
+
+    async def send_command(self, ble_name: str, dp: GenericDP) -> tuple[bool, list[dict] | None]:
+        """Send a command to a WyBot device via BLE.
+
+        Uses binary AA55 format (verified working via PacketLogger capture).
+        Commands are written to the EE01 characteristic.
+
+        Args:
+            ble_name: The BLE advertisement name (usually MAC address like CCBA97932A96)
+            dp: The GenericDP data point to send
+
+        Returns:
+            Tuple of (success: bool, parsed_dps: list[dict] | None)
+            - success: True if command was sent successfully
+            - parsed_dps: List of DP dicts from the response if available
+        """
+        if self._wake_in_progress:
+            _LOGGER.debug("Wake/command already in progress, skipping BLE command")
+            return (False, None)
+
+        self._wake_in_progress = True
+        self._last_notification_data = None
+
+        try:
+            _LOGGER.info(
+                "BLE command: device=%s, DP id=%d, type=%d, len=%d, data=%s",
+                ble_name,
+                dp.id,
+                dp.type,
+                dp.len,
+                dp.data,
+            )
+
+            # Step 1: Find the device
+            device = await self.scan_for_device(ble_name)
+
+            if not device:
+                _LOGGER.info(
+                    "Device %s not found in scan, trying direct MAC connection",
+                    ble_name,
+                )
+                # Convert BLE name to MAC format
+                if len(ble_name) == 12 and all(
+                    c in "0123456789ABCDEFabcdef" for c in ble_name
+                ):
+                    mac_address = ":".join(
+                        ble_name[i : i + 2] for i in range(0, 12, 2)
+                    ).upper()
+                else:
+                    mac_address = ble_name
+
+                ble_device = async_ble_device_from_address(
+                    self._hass, mac_address, connectable=True
+                )
+                if ble_device:
+                    _LOGGER.info("Found device via MAC: %s", mac_address)
+
+                    class DirectDevice:
+                        def __init__(self, addr: str) -> None:
+                            self.address = addr
+                            self.name = f"WyBot-{addr}"
+
+                    device = DirectDevice(mac_address)
+                else:
+                    _LOGGER.warning("Device %s not found for BLE command", ble_name)
+                    return (False, None)
+
+            _LOGGER.info("Connecting to %s for BLE command", device.address)
+
+            try:
+                # Get BLE device through HA's bluetooth module
+                ble_device = async_ble_device_from_address(
+                    self._hass, device.address, connectable=True
+                )
+
+                if not ble_device:
+                    _LOGGER.warning("Could not get BLE device for %s", device.address)
+                    return (False, None)
+
+                # Step 2: Connect to device with timeout
+                async with asyncio.timeout(BLE_COMMAND_TIMEOUT):
+                    client = await establish_connection(
+                        BleakClient,
+                        ble_device,
+                        ble_device.name or ble_device.address,
+                        max_attempts=2,
+                    )
+
+                    try:
+                        if not client.is_connected:
+                            _LOGGER.warning("BLE connection failed")
+                            return (False, None)
+
+                        _LOGGER.info("✓ BLE connected to %s", device.address)
+
+                        # Step 3: Enable notifications to receive response
+                        await self._enable_notifications(client)
+
+                        # Step 4: Build and write command (binary AA55 format to EE01)
+                        payload = self._build_command_payload_binary(dp)
+                        command_written = await self._write_binary_command_to_ee01(
+                            client, payload
+                        )
+
+                        if not command_written:
+                            _LOGGER.warning("BLE command write failed")
+                            return (False, None)
+
+                        # Step 5: Wait briefly for response/acknowledgment
+                        await asyncio.sleep(BLE_COMMAND_HOLD_TIME)
+
+                        # Parse response if available
+                        parsed_dps = None
+                        if self._last_notification_data:
+                            _LOGGER.info(
+                                "BLE response: %s",
+                                self._last_notification_data.hex(),
+                            )
+                            parsed_dps = self._parse_ble_response(self._last_notification_data)
+                            if parsed_dps:
+                                _LOGGER.info("Parsed %d DPs from BLE response", len(parsed_dps))
+
+                        _LOGGER.info("✓ BLE command complete for %s", ble_name)
+                        return (True, parsed_dps)
+
+                    finally:
+                        if client.is_connected:
+                            await client.disconnect()
+
+            except TimeoutError:
+                _LOGGER.warning(
+                    "BLE command timed out for %s (%.1fs)",
+                    ble_name,
+                    BLE_COMMAND_TIMEOUT,
+                )
+                return (False, None)
+            except BleakError as err:
+                _LOGGER.warning("BLE error: %s", err)
+                return (False, None)
+
+        except (BleakError, OSError) as err:
+            _LOGGER.error("BLE command error: %s", err)
+            return (False, None)
+        finally:
+            self._wake_in_progress = False
+
+    def _is_status_response(self, data: bytes) -> bool:
+        """Check if BLE response is a status broadcast (cmd=0x05).
+
+        Args:
+            data: Raw BLE response bytes
+
+        Returns:
+            True if this is a status response with DP data
+        """
+        if len(data) < 6:
+            return False
+        # Check for aa55 header and cmd=0x05 (status)
+        return data[:2] == b"\xaa\x55" and data[3] == 0x05
+
+    def _parse_ble_response(self, data: bytes) -> list[dict]:
+        """Parse BLE response containing DP data.
+
+        WyBot BLE response format (verified via live testing):
+        - Header: aa55 (2 bytes)
+        - Version: 00 (1 byte)
+        - Cmd: 05 = status, 12 = device info, 1c = ack (1 byte)
+        - Length: 2 bytes (big-endian, payload length)
+        - DP data in format: [dp_id 1 byte][type 1 byte][len 1 byte][data...]
+        - Checksum (last byte)
+
+        Args:
+            data: Raw BLE response bytes
+
+        Returns:
+            List of DP dicts: [{"id": int, "type": int, "len": int, "data": str}, ...]
+        """
+        dps = []
+
+        if len(data) < 7:
+            return dps
+
+        try:
+            # Check for WyBot header (aa55)
+            if data[:2] == b'\xaa\x55':
+                version = data[2]
+                cmd = data[3]
+                payload_len = (data[4] << 8) | data[5]
+                offset = 6  # Start of DP data
+                end_offset = min(6 + payload_len, len(data) - 1)  # Exclude checksum
+
+                _LOGGER.debug(
+                    "BLE response: header=aa55, version=%02x, cmd=%02x, payload_len=%d",
+                    version, cmd, payload_len
+                )
+
+                # Only parse DP data for status responses (cmd=0x05)
+                if cmd != 0x05:
+                    _LOGGER.debug("Non-status response (cmd=%02x), skipping DP parse", cmd)
+                    return dps
+
+            elif data[:2] == b'\x55\xaa':
+                # Standard Tuya format: 55aa + version + cmd + 2 len bytes + data
+                offset = 6
+                end_offset = len(data) - 1
+                _LOGGER.debug("BLE response: header=55aa (Tuya format)")
+            else:
+                # Try parsing as raw DP data
+                offset = 0
+                end_offset = len(data)
+                _LOGGER.debug("BLE response: no header, trying raw DP parse")
+
+            # Parse DP data: [dp_id][type][len][data...]
+            # All types use 1-byte length
+            dp_count = 0
+            while offset < end_offset - 2:
+                dp_id = data[offset]
+                dp_type = data[offset + 1]
+                dp_len = data[offset + 2]
+                dp_data_start = offset + 3
+
+                if dp_data_start + dp_len > end_offset:
+                    _LOGGER.debug(
+                        "DP parse: not enough data for DP %d (need %d, have %d)",
+                        dp_id, dp_len, end_offset - dp_data_start
+                    )
+                    break
+
+                dp_data = data[dp_data_start:dp_data_start + dp_len].hex()
+                dp_count += 1
+
+                dps.append({
+                    "id": dp_id,
+                    "type": dp_type,
+                    "len": dp_len,
+                    "data": dp_data,
+                })
+
+                _LOGGER.info(
+                    "Parsed DP %d from BLE: id=%d, type=%d, len=%d, data=%s",
+                    dp_count, dp_id, dp_type, dp_len, dp_data
+                )
+
+                offset = dp_data_start + dp_len
+
+            if dp_count > 0:
+                _LOGGER.info("Successfully parsed %d DPs from BLE response", dp_count)
+
+        except (IndexError, ValueError) as err:
+            _LOGGER.warning("Error parsing BLE response: %s", err)
+
+        return dps
+
+    async def query_status(self, ble_name: str) -> list[dict] | None:
+        """Query device status via BLE.
+
+        Sends a query command and parses the response to get current DP values.
+
+        Args:
+            ble_name: The BLE advertisement name
+
+        Returns:
+            List of DP dicts if successful, None if failed
+        """
+        if self._wake_in_progress:
+            _LOGGER.debug("BLE operation in progress, skipping status query")
+            return None
+
+        self._wake_in_progress = True
+        self._last_notification_data = None
+
+        try:
+            _LOGGER.info("BLE status query for device %s", ble_name)
+
+            # Find the device
+            device = await self.scan_for_device(ble_name)
+            if not device:
+                # Try direct MAC
+                if len(ble_name) == 12 and all(c in "0123456789ABCDEFabcdef" for c in ble_name):
+                    mac_address = ":".join(ble_name[i:i+2] for i in range(0, 12, 2)).upper()
+                else:
+                    mac_address = ble_name
+
+                ble_device = async_ble_device_from_address(self._hass, mac_address, connectable=True)
+                if not ble_device:
+                    _LOGGER.warning("Device %s not found for status query", ble_name)
+                    return None
+
+                class DirectDevice:
+                    def __init__(self, addr: str) -> None:
+                        self.address = addr
+                        self.name = f"WyBot-{addr}"
+                device = DirectDevice(mac_address)
+
+            try:
+                ble_device = async_ble_device_from_address(self._hass, device.address, connectable=True)
+                if not ble_device:
+                    return None
+
+                async with asyncio.timeout(BLE_COMMAND_TIMEOUT):
+                    client = await establish_connection(
+                        BleakClient,
+                        ble_device,
+                        ble_device.name or ble_device.address,
+                        max_attempts=2,
+                    )
+
+                    try:
+                        if not client.is_connected:
+                            return None
+
+                        _LOGGER.info("✓ BLE connected for status query")
+
+                        # Clear previous status data
+                        self._last_status_data = None
+
+                        # Enable notifications
+                        await self._enable_notifications(client)
+
+                        # Send query command (binary AA55 format to EE01)
+                        await self._write_binary_command_to_ee01(
+                            client, CMD_QUERY_STATUS
+                        )
+
+                        # Wait for status broadcast (cmd=0x05)
+                        # The notification handler stores cmd=0x05 in _last_status_data
+                        # so ACKs (cmd=0x1c) don't overwrite it
+                        dps = []
+                        max_wait_time = 5.0  # Max seconds to wait for status
+                        poll_interval = 0.3  # Check every 300ms
+                        elapsed = 0.0
+
+                        while elapsed < max_wait_time:
+                            await asyncio.sleep(poll_interval)
+                            elapsed += poll_interval
+
+                            if self._last_status_data:
+                                _LOGGER.info(
+                                    "Processing status broadcast: %s",
+                                    self._last_status_data.hex()
+                                )
+                                dps = self._parse_ble_response(self._last_status_data)
+                                if dps:
+                                    _LOGGER.info(
+                                        "Parsed %d DPs from status broadcast", len(dps)
+                                    )
+                                    break
+
+                        if not dps:
+                            _LOGGER.warning(
+                                "No status broadcast received after %.1fs", max_wait_time
+                            )
+
+                        # Query CleaningMode (DP 1) separately - not included in general status
+                        if dps:
+                            await asyncio.sleep(0.5)  # Brief delay between queries
+                            self._last_status_data = None  # Clear for next query
+
+                            cleaning_mode_query = self._build_binary_query(1)
+                            _LOGGER.debug(
+                                "Querying CleaningMode (DP 1): %s",
+                                cleaning_mode_query.hex()
+                            )
+                            await self._write_binary_command_to_ee01(
+                                client, cleaning_mode_query
+                            )
+
+                            # Wait for CleaningMode status response
+                            elapsed = 0.0
+                            while elapsed < max_wait_time:
+                                await asyncio.sleep(poll_interval)
+                                elapsed += poll_interval
+
+                                if self._last_status_data:
+                                    cleaning_mode_dps = self._parse_ble_response(
+                                        self._last_status_data
+                                    )
+                                    if cleaning_mode_dps:
+                                        dps.extend(cleaning_mode_dps)
+                                        _LOGGER.info(
+                                            "Added CleaningMode from separate query: %s",
+                                            cleaning_mode_dps
+                                        )
+                                        break
+
+                        return dps if dps else None
+
+                    finally:
+                        if client.is_connected:
+                            await client.disconnect()
+
+            except TimeoutError:
+                _LOGGER.warning("BLE status query timed out")
+                return None
+            except BleakError as err:
+                _LOGGER.warning("BLE error during status query: %s", err)
+                return None
+
+        except (BleakError, OSError) as err:
+            _LOGGER.error("BLE status query error: %s", err)
+            return None
+        finally:
+            self._wake_in_progress = False

--- a/custom_components/wybot/wybot_coordinator.py
+++ b/custom_components/wybot/wybot_coordinator.py
@@ -1,12 +1,18 @@
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 import time
 
-from homeassistant.config_entries import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.config_entries import ConfigEntry, ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .const import (
+    BLE_MAX_CONSECUTIVE_FAILURES,
+    CONF_WIFI_PASSWORD,
+    CONF_WIFI_SSID,
+)
+from .wybot_ble_client import WyBotBLEClient
 from .wybot_dp_models import GenericDP
 from .wybot_http_client import WyBotHTTPClient
 from .wybot_models import Command, Device, Docker, Group
@@ -21,10 +27,17 @@ MAX_RETRY_DELAY = 10.0
 
 
 class WyBotCoordinator(DataUpdateCoordinator):
-    """Coordinates data between WyBot and Homeassistant."""
+    """Coordinates data between WyBot and Homeassistant.
+
+    Architecture: BLE-primary with MQTT fallback
+    - BLE polling is attempted first for all devices in range
+    - MQTT is used only when BLE fails or device is out of range
+    - HTTP session refresh keeps MQTT session alive for fallback
+    """
 
     wybot_http_client: WyBotHTTPClient
     wybot_mqtt_client: WyBotMQTTClient
+    wybot_ble_client: WyBotBLEClient
     hass: HomeAssistant
     data: dict[str, Group]
     initial_load: bool = False
@@ -34,94 +47,382 @@ class WyBotCoordinator(DataUpdateCoordinator):
     _last_status_query_time: float = 0.0
     _online_devices: set[str] = set()
     _initial_query_start_time: float = 0.0
+    _ble_wake_enabled: bool = True
+
+    # BLE command tracking
+    _ble_command_enabled: bool = True
+    _ble_command_failures: dict[str, int]  # device_id -> consecutive failure count
+
+    # WiFi credentials for manual provisioning via diagnostic button
+    _wifi_ssid: str | None = None
+    _wifi_password: str | None = None
+
+    # Track last MQTT data received
+    _last_mqtt_data: dict[str, datetime]  # device_id -> last MQTT data time
+
+    # Track last BLE poll time
+    _last_ble_poll: dict[str, datetime]  # device_id -> last BLE poll time
+
+    # Track data source per device (for diagnostics and logging)
+    _data_source: dict[str, str]  # device_id -> "ble" | "mqtt"
+
+    # Track BLE availability per device
+    _ble_available: dict[str, bool]  # device_id -> last BLE poll succeeded
+
+    # MQTT lazy connection state
+    _mqtt_connected: bool = False
 
     def __init__(
         self,
         hass: HomeAssistant,
         wybot_http_client: WyBotHTTPClient,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(
             hass,
             _LOGGER,
-            # Name of the data. For logging purposes.
+            config_entry=config_entry,
             name="WyBot Coordinator",
-            # Polling interval. Will only be polled if there are subscribers and if no new mqtt data came in,
-            # because of this we set polling to a high value
-            update_interval=timedelta(seconds=120),
+            update_interval=timedelta(seconds=30),
         )
         self.wybot_http_client = wybot_http_client
         self.wybot_mqtt_client = WyBotMQTTClient(self.on_message)
-        self.wybot_mqtt_client.connect()
-        self.hass = hass
+        # DON'T connect MQTT here - use lazy connection when needed as fallback
+        self.wybot_ble_client = WyBotBLEClient(hass)
         self.data = {}
+
+        # Initialize data tracking
+        self._last_mqtt_data = {}
+        self._last_ble_poll = {}
+        self._data_source = {}
+        self._ble_available = {}
+
+        # Initialize BLE command tracking
+        self._ble_command_failures = {}
+
+        # Load WiFi credentials from config entry (for manual provisioning)
+        self._wifi_ssid = config_entry.data.get(CONF_WIFI_SSID)
+        self._wifi_password = config_entry.data.get(CONF_WIFI_PASSWORD)
+        if self._wifi_ssid:
+            _LOGGER.debug(
+                "WiFi credentials loaded for SSID: %s (manual provisioning only)",
+                self._wifi_ssid,
+            )
 
     async def async_stop(self):
         """Stop the MQTT client."""
-        _LOGGER.info("Stopping MQTT client")
-        self.wybot_mqtt_client.disconnect()
+        if self._mqtt_connected:
+            _LOGGER.info("Stopping MQTT client")
+            await self.hass.async_add_executor_job(
+                self.wybot_mqtt_client.disconnect
+            )
+            self._mqtt_connected = False
+
+    async def _ensure_mqtt_connected(self) -> bool:
+        """Lazy connect to MQTT (only when needed as fallback).
+
+        Returns:
+            True if MQTT is connected, False otherwise
+        """
+        if self._mqtt_connected and self.wybot_mqtt_client.is_connected():
+            return True
+
+        _LOGGER.info("Connecting to MQTT (fallback mode)")
+        try:
+            await self.hass.async_add_executor_job(
+                self.wybot_mqtt_client.connect
+            )
+            self._mqtt_connected = True
+            # Subscribe to topics for all known devices
+            if self.data:
+                self.subscribe_mqtt(self.data)
+            _LOGGER.info("MQTT connected successfully (fallback ready)")
+            return True
+        except Exception as err:
+            _LOGGER.warning("MQTT connection failed: %s", err)
+            self._mqtt_connected = False
+            return False
+
+    def _record_mqtt_data_received(self, device_id: str) -> None:
+        """Record that MQTT data was received from a device.
+
+        Used for BLE fallback polling logic.
+
+        Args:
+            device_id: The device ID that sent data
+        """
+        self._last_mqtt_data[device_id] = datetime.now(timezone.utc)
+        _LOGGER.debug("Recorded MQTT data received from device %s", device_id)
+
+    def get_last_ble_communication(self, device_id: str) -> datetime | None:
+        """Get the last successful BLE communication time for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            datetime of last BLE communication, or None if never communicated via BLE
+        """
+        return self._last_ble_poll.get(device_id)
+
+    def get_last_mqtt_communication(self, device_id: str) -> datetime | None:
+        """Get the last MQTT data received time for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            datetime of last MQTT data, or None if never received MQTT data
+        """
+        return self._last_mqtt_data.get(device_id)
+
+    def get_data_source(self, device_id: str) -> str | None:
+        """Get the current data source for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            "ble" or "mqtt" depending on last successful poll, or None if unknown
+        """
+        return self._data_source.get(device_id)
+
+    def is_ble_available(self, device_id: str) -> bool | None:
+        """Check if BLE is available for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            True if last BLE poll succeeded, False if failed, None if never tried
+        """
+        return self._ble_available.get(device_id)
+
+    def _get_device_ble_info(self, group: Group) -> tuple[str | None, str | None]:
+        """Get the BLE name and device ID for a group.
+
+        Prefers docker BLE name since dock relays to robot.
+
+        Args:
+            group: The device group
+
+        Returns:
+            Tuple of (ble_name, device_id) or (None, None) if no BLE available
+        """
+        if group.docker and group.docker.ble_name:
+            return group.docker.ble_name, group.docker.docker_id
+        if group.device and group.device.ble_name:
+            return group.device.ble_name, group.device.device_id
+        return None, None
+
+    def _update_device_dps_from_ble(
+        self, group: Group, device_id: str, dps: list[dict]
+    ) -> None:
+        """Update device DPs from BLE response.
+
+        Args:
+            group: The device group to update
+            device_id: The device ID
+            dps: List of DP dicts from BLE response
+        """
+        if not dps:
+            return
+
+        # Create a command-like structure to reuse existing DP processing
+        cmd_data = {"cmd": 5, "ts": 0, "dp": dps}
+        command = Command(**cmd_data)
+        dp_dict = command.get_dps_as_keyed_dict()
+
+        if group.docker and group.docker.docker_id == device_id:
+            group.docker.dps = {**group.docker.dps, **dp_dict}
+            _LOGGER.debug(
+                "Updated docker %s DPs from BLE: %s",
+                device_id,
+                list(dp_dict.keys()),
+            )
+        elif group.device:
+            group.device.dps = {**group.device.dps, **dp_dict}
+            _LOGGER.debug(
+                "Updated device %s DPs from BLE: %s",
+                device_id,
+                list(dp_dict.keys()),
+            )
+
+    async def _poll_all_devices_via_ble(self) -> list[str]:
+        """Poll all devices via BLE (primary data source).
+
+        BLE provides faster, more reliable local communication when the device
+        is in range. This is the PRIMARY data source in the BLE-first architecture.
+
+        Returns:
+            List of device IDs that need MQTT fallback (failed BLE or no BLE name)
+        """
+        devices_needing_mqtt: list[str] = []
+        now = datetime.now(timezone.utc)
+
+        for group_id, group in self.data.items():
+            ble_name, device_id = self._get_device_ble_info(group)
+
+            if not ble_name or not device_id:
+                # No BLE name available, will need MQTT
+                if group.device:
+                    devices_needing_mqtt.append(group.device.device_id)
+                continue
+
+            _LOGGER.debug(
+                "BLE polling device %s via %s (primary)",
+                device_id,
+                ble_name,
+            )
+
+            try:
+                dps = await self.wybot_ble_client.query_status(ble_name)
+
+                if dps:
+                    _LOGGER.info(
+                        "✓ BLE poll success for %s: %d DPs received",
+                        device_id,
+                        len(dps),
+                    )
+                    self._update_device_dps_from_ble(group, device_id, dps)
+                    self.data[group_id] = group
+
+                    # Track successful BLE poll
+                    self._last_ble_poll[device_id] = now
+                    self._data_source[device_id] = "ble"
+                    self._ble_available[device_id] = True
+                else:
+                    # BLE returned no data, need MQTT fallback
+                    _LOGGER.debug(
+                        "BLE poll for %s returned no data, using MQTT fallback",
+                        device_id,
+                    )
+                    devices_needing_mqtt.append(device_id)
+                    self._ble_available[device_id] = False
+
+            except Exception as err:
+                _LOGGER.debug(
+                    "BLE poll failed for %s: %s, using MQTT fallback",
+                    device_id,
+                    err,
+                )
+                devices_needing_mqtt.append(device_id)
+                self._ble_available[device_id] = False
+
+        return devices_needing_mqtt
+
+    async def _poll_devices_via_mqtt(self, device_ids: list[str]) -> None:
+        """Poll specific devices via MQTT (fallback).
+
+        Only called when BLE fails or device is out of range.
+
+        Args:
+            device_ids: List of device IDs that need MQTT polling
+        """
+        if not device_ids:
+            return
+
+        # Ensure MQTT is connected (lazy connection)
+        if not await self._ensure_mqtt_connected():
+            _LOGGER.warning(
+                "MQTT fallback unavailable for %d devices",
+                len(device_ids),
+            )
+            return
+
+        _LOGGER.info(
+            "Using MQTT fallback for %d devices: %s",
+            len(device_ids),
+            device_ids,
+        )
+
+        for device_id in device_ids:
+            self.wybot_mqtt_client.ensure_device_sends_statuses(device_id)
+            self._data_source[device_id] = "mqtt"
+            self._last_status_query_time = time.time()
+
+    async def _maybe_refresh_http_session(self) -> None:
+        """Periodically refresh HTTP session to keep MQTT fallback ready.
+
+        The WyBot cloud may only relay MQTT data for "active" users,
+        so we need to periodically refresh the HTTP session.
+        """
+        current_time = time.time()
+        if not hasattr(self, "_last_http_refresh_time"):
+            self._last_http_refresh_time = 0.0
+
+        # Refresh every 60 seconds
+        if current_time - self._last_http_refresh_time < 60.0:
+            return
+
+        _LOGGER.debug("Refreshing HTTP session to keep MQTT fallback ready")
+        try:
+            await self.hass.async_add_executor_job(
+                self.wybot_http_client.register_presence
+            )
+            await self.hass.async_add_executor_job(
+                self.wybot_http_client.get_devices_and_status
+            )
+            self._last_http_refresh_time = current_time
+        except Exception as err:
+            _LOGGER.debug("HTTP refresh failed (non-critical): %s", err)
 
     async def _async_update_data(self):
-        """Fetch data from API endpoint.
+        """Fetch data using BLE-primary with MQTT fallback architecture.
 
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
+        Priority:
+        1. BLE polling (primary) - for devices in Bluetooth range
+        2. MQTT polling (fallback) - for devices that failed BLE
+        3. HTTP session refresh - keeps MQTT fallback ready
         """
         try:
             async with asyncio.timeout(30):
-                # First update, fill the array from HTTP and then subscribe to MQTT
-                if self.initial_load is False:
+                # First update: HTTP setup to get device list
+                if not self.initial_load:
                     self.initial_load = True
+                    _LOGGER.info("Initial load: fetching device list from HTTP API")
+                    await self.hass.async_add_executor_job(
+                        self.wybot_http_client.register_presence
+                    )
                     await self.http_refresh_data()
-                    self._initial_query_start_time = time.time()
-                    # Query all devices immediately after subscription (like iOS app does on open)
-                    if self.wybot_mqtt_client.is_connected():
-                        await self.query_all_known_devices()
-                        self._last_status_query_time = time.time()
 
-                # Ensure MQTT connection is active
-                if not self.wybot_mqtt_client.is_connected():
-                    _LOGGER.debug("MQTT not connected, attempting reconnection")
-                    reconnected = await self.wybot_mqtt_client.async_reconnect()
-                    if not reconnected:
-                        self._mqtt_failure_count += 1
-                        if self._mqtt_failure_count >= 3:
-                            _LOGGER.warning(
-                                "MQTT connection failed multiple times, marking as unavailable"
+                    # Log device BLE names for debugging
+                    for group_id, group in self.data.items():
+                        if group.device:
+                            _LOGGER.info(
+                                "Device %s BLE name: %s, type: %s",
+                                group.device.device_id,
+                                group.device.ble_name,
+                                group.device.device_type,
                             )
-                            self._connection_available = False
-                    else:
-                        self._mqtt_failure_count = 0
-                        if not self._connection_available:
-                            _LOGGER.info("MQTT connection restored")
-                            self._connection_available = True
+                        if group.docker:
+                            _LOGGER.info(
+                                "Docker %s BLE name: %s, type: %s",
+                                group.docker.docker_id,
+                                group.docker.ble_name,
+                                group.docker.docker_type,
+                            )
+                    self._initial_query_start_time = time.time()
+
+                # BLE FIRST - try all devices via BLE (primary)
+                devices_needing_mqtt = await self._poll_all_devices_via_ble()
+
+                # MQTT FALLBACK - only for devices that failed BLE
+                if devices_needing_mqtt:
+                    await self._poll_devices_via_mqtt(devices_needing_mqtt)
+
+                # Keep HTTP session active for MQTT fallback readiness
+                await self._maybe_refresh_http_session()
+
+                # Update connection availability based on data sources
+                if self.data:
+                    self._connection_available = True
                 else:
-                    self._mqtt_failure_count = 0
-                    if not self._connection_available:
-                        _LOGGER.info("Connection restored")
-                        self._connection_available = True
-                        # Query all devices immediately when connection is restored (like iOS app does on open)
-                        if self.wybot_mqtt_client.is_connected():
-                            await self.query_all_known_devices()
-                            self._last_status_query_time = time.time()
-
-                # Periodically query device status to replicate phone app behavior
-                # Query more frequently initially (every 5 seconds for first minute), then every 10 seconds
-                current_time = time.time()
-                time_since_initial = (
-                    current_time - self._initial_query_start_time
-                    if self._initial_query_start_time > 0
-                    else 60.0
-                )
-                query_interval = 5.0 if time_since_initial < 60.0 else 10.0
-
-                if current_time - self._last_status_query_time >= query_interval:
-                    if self.wybot_mqtt_client.is_connected():
-                        # Use async version with delays to match iOS app behavior
-                        await self.query_online_devices_async()
-                        self._last_status_query_time = current_time
+                    self._connection_available = False
 
                 return self.data
+
         except TimeoutError as err:
             _LOGGER.error("Timeout updating data: %s", err)
             self._connection_available = False
@@ -132,7 +433,11 @@ class WyBotCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
     async def http_refresh_data(self):
-        """Refresh data from HTTP API with retry logic."""
+        """Refresh data from HTTP API with retry logic.
+
+        Note: Does not subscribe to MQTT here since MQTT uses lazy connection.
+        MQTT subscription happens in _ensure_mqtt_connected() when needed as fallback.
+        """
         delay = INITIAL_RETRY_DELAY
         last_error = None
 
@@ -143,7 +448,7 @@ class WyBotCoordinator(DataUpdateCoordinator):
                 )
                 if data:
                     self.data = data
-                    self.subscribe_mqtt(self.data)
+                    # Note: MQTT subscription deferred to _ensure_mqtt_connected()
                     self._http_failure_count = 0
                     self._connection_available = True
                     return
@@ -193,50 +498,79 @@ class WyBotCoordinator(DataUpdateCoordinator):
         raise UpdateFailed("Failed to refresh data after retries")
 
     def subscribe_mqtt(self, data: dict[str, Group]):
-        """Subscribe to MQTT updates for devices.
-
-        Subscribes to all topics (initial and response) for all devices upfront,
-        matching iOS app behavior where all subscriptions happen at once.
-        """
+        """Subscribe to MQTT updates for a device."""
         for [deviceId, device] in data.items():
-            # Subscribe to all topics for both device and docker upfront
-            # This matches iOS app behavior where both devices' topics are subscribed at once
-            self.wybot_mqtt_client.subscribe_for_device_initial(device.device.device_id)
             self.wybot_mqtt_client.subscribe_for_device(device.device.device_id)
             if device.docker is not None:
-                self.wybot_mqtt_client.subscribe_for_device_initial(
-                    device.docker.docker_id
-                )
                 self.wybot_mqtt_client.subscribe_for_device(device.docker.docker_id)
 
     def on_message(self, topic: str, data: dict[str, any]):
         """Handle a message from MQTT."""
         data_updated = False
 
+        # Enhanced logging to debug MQTT message flow
+        _LOGGER.info(
+            "MQTT on_message called - Topic: %s, Data keys: %s, cmd: %s",
+            topic,
+            list(data.keys()) if isinstance(data, dict) else "not-a-dict",
+            data.get("cmd") if isinstance(data, dict) else "N/A",
+        )
+
         if topic.startswith("/will/"):
             deviceId = topic[6:]
             is_online = data.get("online") == "1"
-            _LOGGER.debug("Received device online %s with %s", deviceId, is_online)
-            # Track online status
-            if is_online:
-                self._online_devices.add(deviceId)
-                # Query immediately when device comes online using iOS app pattern
-                # This implements: initial query -> subscribe to responses -> remaining queries
-                # Must use add_job since we're in MQTT callback thread
-                if self.wybot_mqtt_client.is_connected():
-                    self.hass.add_job(
-                        self.wybot_mqtt_client.query_device_ios_pattern,
-                        deviceId,
-                    )
-            else:
-                self._online_devices.discard(deviceId)
+            _LOGGER.info(
+                "Device %s online status changed to: %s",
+                deviceId,
+                "online" if is_online else "offline",
+            )
+            # Record that we received MQTT data from this device
+            self._record_mqtt_data_received(deviceId)
+            # Update device online status
+            group = self.get_group(deviceId)
+            if group is not None:
+                if group.device.device_id == deviceId:
+                    group.device.online = is_online
+                elif group.docker is not None and group.docker.docker_id == deviceId:
+                    group.docker.online = is_online
+                self.data[group.id] = group
+                # Track online devices
+                if is_online:
+                    self._online_devices.add(deviceId)
+                    # Device just came online, query for status immediately
+                    _LOGGER.info("Device %s came online, querying status", deviceId)
+                    self.wybot_mqtt_client.ensure_device_sends_statuses(deviceId)
+                else:
+                    self._online_devices.discard(deviceId)
             # Will messages indicate device availability changes, always trigger update
             data_updated = True
 
         if topic.startswith("/device/DATA/send_transparent_data/"):
             deviceId = topic[35:]
-            command_response = Command(**data)
+            # Record that we received MQTT data from this device
+            self._record_mqtt_data_received(deviceId)
+            _LOGGER.info(
+                "Processing send_transparent_data for device %s, raw data: %s",
+                deviceId,
+                data,
+            )
+            try:
+                command_response = Command(**data)
+                _LOGGER.info(
+                    "Parsed Command: cmd=%s, dp_count=%s, dps=%s",
+                    command_response.cmd,
+                    len(command_response.dp),
+                    [{"id": dp.id, "type": dp.type, "len": dp.len, "data": dp.data} for dp in command_response.dp],
+                )
+            except Exception as err:
+                _LOGGER.error("Failed to parse Command from data: %s, error: %s", data, err)
+                command_response = None
+
+            if command_response is None:
+                return
+
             group = self.get_group(deviceId)
+            _LOGGER.info("Found group for device %s: %s", deviceId, group.id if group else None)
             if (
                 group is not None
                 and group.docker is not None
@@ -246,7 +580,7 @@ class WyBotCoordinator(DataUpdateCoordinator):
                     **group.docker.dps,
                     **command_response.get_dps_as_keyed_dict(),
                 }
-                _LOGGER.debug(
+                _LOGGER.info(
                     "SEND RESPONSE ---- docker - %s ---- Current DPs: %s",
                     deviceId,
                     group.docker.dps,
@@ -257,7 +591,7 @@ class WyBotCoordinator(DataUpdateCoordinator):
                     **group.device.dps,
                     **command_response.get_dps_as_keyed_dict(),
                 }
-                _LOGGER.debug(
+                _LOGGER.info(
                     "SEND RESPONSE ---- device - %s ---- Current DPs: %s",
                     deviceId,
                     group.device.dps,
@@ -268,13 +602,46 @@ class WyBotCoordinator(DataUpdateCoordinator):
 
         if topic.startswith("/device/DATA/recv_transparent_query_data/"):
             deviceId = topic[41:]
+            # Record that we received MQTT data from this device
+            self._record_mqtt_data_received(deviceId)
             command_response = Command(**data)
             _LOGGER.debug("Query CMD ---- %s ----- %s", deviceId, command_response)
 
         if topic.startswith("/device/DATA/recv_transparent_cmd_data/"):
             deviceId = topic[39:]
+            # Record that we received MQTT data from this device
+            self._record_mqtt_data_received(deviceId)
             command_response = Command(**data)
             _LOGGER.debug("SEND CMD ---- %s ----- %s", deviceId, command_response)
+
+            # Update device DPs with the received data (cmd=4 contains actual values)
+            group = self.get_group(deviceId)
+            if group is not None:
+                if (
+                    group.docker is not None
+                    and group.docker.docker_id == deviceId
+                ):
+                    group.docker.dps = {
+                        **group.docker.dps,
+                        **command_response.get_dps_as_keyed_dict(),
+                    }
+                    _LOGGER.info(
+                        "Updated docker %s DPs from cmd_data: %s",
+                        deviceId,
+                        command_response.get_dps_as_keyed_dict(),
+                    )
+                elif group.device is not None:
+                    group.device.dps = {
+                        **group.device.dps,
+                        **command_response.get_dps_as_keyed_dict(),
+                    }
+                    _LOGGER.info(
+                        "Updated device %s DPs from cmd_data: %s",
+                        deviceId,
+                        command_response.get_dps_as_keyed_dict(),
+                    )
+                self.data[group.id] = group
+                data_updated = True
 
         # Always trigger update when we receive MQTT messages to ensure state is written
         # This ensures history is recorded even if computed state values don't change
@@ -300,7 +667,7 @@ class WyBotCoordinator(DataUpdateCoordinator):
 
     def send_write_command(self, group: Group, dp: GenericDP):
         """Send a command to a group. First send to the device, then send to the docker if it exists."""
-        command = {"ts": time.time(), "cmd": 4, "dp": [dp.dict()]}
+        command = {"ts": int(time.time()), "cmd": 4, "dp": [dp.dict()]}
         self.wybot_mqtt_client.send_write_command_for_device(
             group.device.device_id, command
         )
@@ -309,9 +676,174 @@ class WyBotCoordinator(DataUpdateCoordinator):
                 group.docker.docker_id, command
             )
 
+    async def async_send_command(self, group: Group, dp: GenericDP) -> bool:
+        """Send a command using BLE-first strategy with MQTT fallback.
+
+        Attempts to send commands via BLE first (more reliable when WiFi is flaky).
+        Falls back to MQTT if BLE fails or is disabled for this device.
+
+        Args:
+            group: The device group to send the command to
+            dp: The GenericDP data point to send
+
+        Returns:
+            True if command was sent successfully via either BLE or MQTT
+        """
+        device_id = group.device.device_id
+        ble_name = None
+
+        # Prefer docker BLE name (dock has BLE, relays to robot)
+        if group.docker and group.docker.ble_name:
+            ble_name = group.docker.ble_name
+        elif group.device and group.device.ble_name:
+            ble_name = group.device.ble_name
+
+        # Check if BLE commands are enabled for this device
+        ble_enabled = (
+            self._ble_command_enabled
+            and ble_name is not None
+            and self._ble_command_failures.get(device_id, 0) < BLE_MAX_CONSECUTIVE_FAILURES
+        )
+
+        if ble_enabled:
+            _LOGGER.info(
+                "Attempting BLE-first command for device %s via %s (DP id=%d)",
+                device_id,
+                ble_name,
+                dp.id,
+            )
+            try:
+                ble_success, ble_dps = await self.wybot_ble_client.send_command(ble_name, dp)
+
+                if ble_success:
+                    _LOGGER.info(
+                        "✓ BLE command succeeded for device %s",
+                        device_id,
+                    )
+                    # Reset failure count on success
+                    self._ble_command_failures[device_id] = 0
+
+                    # Update state from BLE response if we got DPs
+                    if ble_dps:
+                        self._update_from_ble_dps(group, device_id, ble_dps)
+
+                    return True
+
+                # BLE failed, increment failure count
+                failures = self._ble_command_failures.get(device_id, 0) + 1
+                self._ble_command_failures[device_id] = failures
+                _LOGGER.warning(
+                    "BLE command failed for device %s (failure %d/%d), falling back to MQTT",
+                    device_id,
+                    failures,
+                    BLE_MAX_CONSECUTIVE_FAILURES,
+                )
+
+                if failures >= BLE_MAX_CONSECUTIVE_FAILURES:
+                    _LOGGER.warning(
+                        "BLE commands disabled for device %s after %d consecutive failures",
+                        device_id,
+                        failures,
+                    )
+
+            except Exception as err:
+                # BLE failed with exception, increment failure count
+                failures = self._ble_command_failures.get(device_id, 0) + 1
+                self._ble_command_failures[device_id] = failures
+                _LOGGER.warning(
+                    "BLE command exception for device %s: %s (failure %d/%d), falling back to MQTT",
+                    device_id,
+                    err,
+                    failures,
+                    BLE_MAX_CONSECUTIVE_FAILURES,
+                )
+        else:
+            if ble_name is None:
+                _LOGGER.debug(
+                    "No BLE name available for device %s, using MQTT",
+                    device_id,
+                )
+            elif not self._ble_command_enabled:
+                _LOGGER.debug(
+                    "BLE commands globally disabled, using MQTT for device %s",
+                    device_id,
+                )
+            else:
+                _LOGGER.debug(
+                    "BLE commands disabled for device %s (too many failures), using MQTT",
+                    device_id,
+                )
+
+        # Fallback to MQTT
+        _LOGGER.info(
+            "Sending MQTT command for device %s (DP id=%d)",
+            device_id,
+            dp.id,
+        )
+        self.send_write_command(group, dp)
+        return True  # MQTT is fire-and-forget, assume success
+
+    def reset_ble_command_failures(self, device_id: str | None = None) -> None:
+        """Reset BLE command failure count for a device or all devices.
+
+        Args:
+            device_id: Specific device to reset, or None to reset all
+        """
+        if device_id:
+            self._ble_command_failures.pop(device_id, None)
+            _LOGGER.info("Reset BLE command failures for device %s", device_id)
+        else:
+            self._ble_command_failures.clear()
+            _LOGGER.info("Reset BLE command failures for all devices")
+
+    def _update_from_ble_dps(self, group: Group, device_id: str, dps: list[dict]) -> None:
+        """Update device state from BLE response DPs.
+
+        Args:
+            group: The device group to update
+            device_id: The device ID
+            dps: List of DP dicts from BLE response
+        """
+        if not dps:
+            return
+
+        try:
+            from .wybot_models import Command
+
+            # Create a command-like structure to reuse existing DP processing
+            cmd_data = {"cmd": 5, "ts": 0, "dp": dps}
+            command = Command(**cmd_data)
+
+            dp_dict = command.get_dps_as_keyed_dict()
+
+            # Update the appropriate device/docker
+            if group.docker and group.docker.docker_id == device_id:
+                group.docker.dps = {**group.docker.dps, **dp_dict}
+                _LOGGER.info(
+                    "Updated docker %s DPs from BLE response: %s",
+                    device_id,
+                    list(dp_dict.keys()),
+                )
+            elif group.device:
+                group.device.dps = {**group.device.dps, **dp_dict}
+                _LOGGER.info(
+                    "Updated device %s DPs from BLE response: %s",
+                    device_id,
+                    list(dp_dict.keys()),
+                )
+
+            # Record that we got data
+            self._last_mqtt_data[device_id] = datetime.now(timezone.utc)
+
+            # Trigger a state update
+            self.async_set_updated_data(self.data)
+
+        except Exception as err:
+            _LOGGER.warning("Error updating state from BLE DPs: %s", err)
+
     def query_all_device_status(self) -> None:
         """Query status for all devices by sending individual DP queries."""
-        for device_id in self.data:
+        for device_id in self.data.keys():
             group = self.data[device_id]
             if self.wybot_mqtt_client.is_connected():
                 self.wybot_mqtt_client.ensure_device_sends_statuses(
@@ -322,77 +854,58 @@ class WyBotCoordinator(DataUpdateCoordinator):
                         group.docker.docker_id
                     )
 
-    def query_online_devices(self) -> None:
-        """Query status only for online devices by sending individual DP queries.
+    async def async_wake_devices_ble(self) -> dict[str, bool]:
+        """Wake all offline devices via BLE.
 
-        If no devices are tracked as online yet, query all devices (initial state).
-        Note: This is a sync method, so queries are sent immediately without delays.
-        For async version with delays, use query_online_devices_async.
+        Returns:
+            Dict mapping device BLE name to wake success status
         """
-        for device_id in self.data:
-            group = self.data[device_id]
-            if self.wybot_mqtt_client.is_connected():
-                # If we haven't tracked any online devices yet, query all (initial state)
-                # Otherwise, only query if device is online
-                if (
-                    not self._online_devices
-                    or group.device.device_id in self._online_devices
-                ):
-                    self.wybot_mqtt_client.ensure_device_sends_statuses(
-                        group.device.device_id
-                    )
-                # Always query docker if it exists and (we're in initial state or it's online)
-                if group.docker is not None:
-                    if (
-                        not self._online_devices
-                        or group.docker.docker_id in self._online_devices
-                    ):
-                        self.wybot_mqtt_client.ensure_device_sends_statuses(
-                            group.docker.docker_id
-                        )
+        if not self._ble_wake_enabled:
+            _LOGGER.debug("BLE wake is disabled")
+            return {}
 
-    async def query_all_known_devices(self) -> None:
-        """Query all known devices using iOS app pattern.
+        # Collect BLE names for all devices that are offline
+        ble_names_to_wake = []
+        for group_id, group in self.data.items():
+            # Check if device is offline and has BLE name
+            if group.device and group.device.ble_name:
+                if not group.device.online:
+                    ble_names_to_wake.append(group.device.ble_name)
+            if group.docker and group.docker.ble_name:
+                if not group.docker.online:
+                    ble_names_to_wake.append(group.docker.ble_name)
 
-        This queries both device and docker for all groups, matching the iOS app
-        behavior where all devices are queried immediately after subscription.
+        if not ble_names_to_wake:
+            _LOGGER.debug("No offline devices to wake via BLE")
+            return {}
+
+        _LOGGER.info("Attempting to wake %d offline devices via BLE", len(ble_names_to_wake))
+        results = await self.wybot_ble_client.wake_devices(ble_names_to_wake)
+
+        # Log results
+        for ble_name, success in results.items():
+            if success:
+                _LOGGER.info("Successfully woke device %s via BLE", ble_name)
+            else:
+                _LOGGER.warning("Failed to wake device %s via BLE", ble_name)
+
+        return results
+
+    async def async_wake_device_ble(self, ble_name: str) -> bool:
+        """Wake a specific device via BLE.
+
+        Args:
+            ble_name: The BLE name of the device to wake
+
+        Returns:
+            True if wake was successful
         """
-        for device_id in self.data:
-            group = self.data[device_id]
-            if self.wybot_mqtt_client.is_connected():
-                # Query device using iOS pattern
-                await self.wybot_mqtt_client.query_device_ios_pattern(
-                    group.device.device_id
-                )
-                # Query docker if it exists
-                if group.docker is not None:
-                    await self.wybot_mqtt_client.query_device_ios_pattern(
-                        group.docker.docker_id
-                    )
+        if not self._ble_wake_enabled:
+            _LOGGER.debug("BLE wake is disabled")
+            return False
 
-    async def query_online_devices_async(self) -> None:
-        """Query status only for online devices with delays matching iOS app behavior."""
-        for device_id in self.data:
-            group = self.data[device_id]
-            if self.wybot_mqtt_client.is_connected():
-                # If we haven't tracked any online devices yet, query all (initial state)
-                # Otherwise, only query if device is online
-                if (
-                    not self._online_devices
-                    or group.device.device_id in self._online_devices
-                ):
-                    await self.wybot_mqtt_client.query_device_ios_pattern(
-                        group.device.device_id
-                    )
-                # Always query docker if it exists and (we're in initial state or it's online)
-                if group.docker is not None:
-                    if (
-                        not self._online_devices
-                        or group.docker.docker_id in self._online_devices
-                    ):
-                        await self.wybot_mqtt_client.query_device_ios_pattern(
-                            group.docker.docker_id
-                        )
+        _LOGGER.info("Attempting to wake device %s via BLE", ble_name)
+        return await self.wybot_ble_client.wake_device(ble_name)
 
     @property
     def available(self) -> bool:

--- a/custom_components/wybot/wybot_dp_models.py
+++ b/custom_components/wybot/wybot_dp_models.py
@@ -52,9 +52,11 @@ class GenericDP:
 
 class CleaningStatusMode(Enum):
     STOPPED = 1
+    RETURNING = 2  # Legacy/intermediate returning state
     CLEANING = 3
-    STARTING = 255
+    RETURNING_TO_DOCK = 4  # Returning after "return to dock" command
     UNKNOWN = 15
+    STARTING = 255
 
 
 # Send 03 to start
@@ -88,9 +90,9 @@ class CleaningStatus(GenericDP):
 
 
 class DockStatus(Enum):
-    DOCKED = 0  # Device is docked
-    RETURNING = 1  # Device is returning to dock
-    GENERAL = 3  # General/unknown status
+    DOCKED = 0  # Robot is docked/idle
+    RETURNING = 1
+    GENERAL = 3
 
 
 #  Send 01 to go back to dock
@@ -130,10 +132,10 @@ class CleaningMode(GenericDP):
     CLEANING_MODES = [
         "Floor",
         "Wall",
-        "Wall then Foor",
-        "Standard Full-Pool",
+        "Wall Then Floor",
+        "Advanced Full Pool",
         "Water Line",
-        "Strong Floor",
+        "Turbo Floor",
         "Eco Floor",
     ]
 
@@ -191,19 +193,262 @@ class Battery(GenericDP):
         return f"({__class__.__name__}, charge_state={self.charge_state}, battery_level={self.battery_level})"
 
 
+class SolarEnergyHarvested(GenericDP):
+    """DP 131: Total solar energy harvested in Wh (little-endian 4-byte value)."""
+
+    id = 131
+    type = 2
+    len = 4
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def energy_wh(self) -> int:
+        """Return total solar energy harvested in Wh."""
+        if self.data is None or len(self.data) < 8:
+            return 0
+        # Data is little-endian, convert to int
+        return int.from_bytes(bytes.fromhex(self.data), byteorder="little")
+
+    @property
+    def energy_kwh(self) -> float:
+        """Return total solar energy harvested in kWh."""
+        return self.energy_wh / 1000.0
+
+    def __str__(self):
+        return f"({__class__.__name__}, energy_wh={self.energy_wh}, energy_kwh={self.energy_kwh})"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, energy_wh={self.energy_wh}, energy_kwh={self.energy_kwh})"
+
+
+class SolarDockBattery(GenericDP):
+    """DP 221: Solar dock battery level (3-byte format).
+
+    Data format: XXYYZZ (3 bytes / 6 hex chars)
+    - XX: Status/flags byte (typically 01)
+    - YY: Battery percentage (0-100)
+    - ZZ: Unknown (possibly voltage related)
+
+    Example: "01480a" = 72% battery (0x48 = 72)
+    """
+
+    id = 221
+    type = 0
+    len = 3
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def battery_level(self) -> int:
+        """Return solar dock battery level as percentage (0-100)."""
+        if self.data is None or len(self.data) < 4:
+            return 0
+        # Battery percentage is in byte 1 (hex chars 2-3)
+        # Example: "01480a" -> "48" -> 72%
+        try:
+            return int(self.data[2:4], 16)
+        except (ValueError, IndexError):
+            return 0
+
+    def __str__(self):
+        return f"({__class__.__name__}, battery_level={self.battery_level}%)"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, battery_level={self.battery_level}%)"
+
+
+class SolarStatusMode(Enum):
+    """Solar charging status modes."""
+
+    NOT_CHARGING = 0
+    CHARGING = 1
+
+
+class SolarStatus(GenericDP):
+    """DP 222: Solar charging status (1-byte boolean)."""
+
+    id = 222
+    type = 0
+    len = 1
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def is_charging(self) -> bool:
+        """Return True if solar panel is actively charging."""
+        if self.data is None:
+            return False
+        return int(self.data, 16) == 1
+
+    @property
+    def status(self) -> SolarStatusMode:
+        """Return the solar charging status mode."""
+        if self.data is None:
+            return SolarStatusMode.NOT_CHARGING
+        return SolarStatusMode(int(self.data, 16))
+
+    def __str__(self):
+        return f"({__class__.__name__}, is_charging={self.is_charging})"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, is_charging={self.is_charging})"
+
+
+class DockType(Enum):
+    """Dock type based on DP 214 values."""
+
+    UNKNOWN = 0
+    STANDARD = 1
+    SOLAR = 5  # S2 Pro solar dock appears to report 5
+
+
+class DockInfo(GenericDP):
+    """DP 214: Dock type information."""
+
+    id = 214
+    type = 4
+    len = 1
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def dock_type(self) -> DockType:
+        """Return the dock type."""
+        if self.data is None:
+            return DockType.UNKNOWN
+        try:
+            return DockType(int(self.data, 16))
+        except ValueError:
+            return DockType.UNKNOWN
+
+    @property
+    def is_solar_dock(self) -> bool:
+        """Return True if this is a solar dock."""
+        return self.dock_type == DockType.SOLAR
+
+    def __str__(self):
+        return f"({__class__.__name__}, dock_type={self.dock_type}, is_solar_dock={self.is_solar_dock})"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, dock_type={self.dock_type}, is_solar_dock={self.is_solar_dock})"
+
+
+class Schedule(GenericDP):
+    """DP 79: Schedule data (12-byte value containing schedule configuration)."""
+
+    id = 79
+    type = 2
+    len = 12
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def raw_schedule(self) -> str:
+        """Return raw schedule data as hex string."""
+        return self.data if self.data else ""
+
+    def __str__(self):
+        return f"({__class__.__name__}, raw_schedule={self.raw_schedule})"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, raw_schedule={self.raw_schedule})"
+
+
+class DeviceStatus(GenericDP):
+    """DP 209: Device status flag."""
+
+    id = 209
+    type = 4
+    len = 1
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def status_value(self) -> int:
+        """Return the raw status value."""
+        if self.data is None:
+            return 0
+        return int(self.data, 16)
+
+    def __str__(self):
+        return f"({__class__.__name__}, status_value={self.status_value})"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, status_value={self.status_value})"
+
+
+class ConnectionStatus(GenericDP):
+    """DP 212: Connection/communication status."""
+
+    id = 212
+    type = 4
+    len = 1
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def is_connected(self) -> bool:
+        """Return True if device is connected."""
+        if self.data is None:
+            return False
+        return int(self.data, 16) == 1
+
+    def __str__(self):
+        return f"({__class__.__name__}, is_connected={self.is_connected})"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, is_connected={self.is_connected})"
+
+
+class DockConnectionStatus(GenericDP):
+    """DP 213: Dock connection status."""
+
+    id = 213
+    type = 4
+    len = 1
+
+    def __init__(self, data: DP) -> None:
+        super().__init__(data)
+
+    @property
+    def is_docked(self) -> bool:
+        """Return True if device is docked."""
+        if self.data is None:
+            return False
+        return int(self.data, 16) == 1
+
+    def __str__(self):
+        return f"({__class__.__name__}, is_docked={self.is_docked})"
+
+    def __repr__(self):
+        return f"({__class__.__name__}, is_docked={self.is_docked})"
+
+
 # Mapping of types to classes
 wybot_dp_id = {
     0: CleaningStatus,
     1: CleaningMode,
     11: Dock,  # Docking status
-    13: GenericDP,
+    13: GenericDP,  # Unknown 4-byte value
     15: GenericDP,
     50: Battery,
-    77: GenericDP,
-    79: GenericDP,
-    131: GenericDP,
-    209: GenericDP,
-    213: GenericDP,
-    214: GenericDP,
+    77: GenericDP,  # Unknown 36-byte data (cleaning map/log?)
+    79: Schedule,  # Schedule configuration
+    131: SolarEnergyHarvested,  # Total solar energy harvested (Wh)
+    209: DeviceStatus,  # Device status flag
+    212: ConnectionStatus,  # Connection status
+    213: DockConnectionStatus,  # Dock connection status
+    214: DockInfo,  # Dock type information
+    221: SolarDockBattery,  # Solar dock battery level (%)
+    222: SolarStatus,  # Solar charging status
+    223: GenericDP,  # Unknown 4-byte value
     # Add more mappings as needed
 }

--- a/custom_components/wybot/wybot_dp_models.py
+++ b/custom_components/wybot/wybot_dp_models.py
@@ -1,12 +1,12 @@
 from enum import Enum
 import logging
 
-from pydantic import v1 as pydantic_v1
+from pydantic import BaseModel
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DP(pydantic_v1.BaseModel):
+class DP(BaseModel):
     """Represents the response for a device command operation."""
 
     # Represents a data point for a command.
@@ -16,9 +16,9 @@ class DP(pydantic_v1.BaseModel):
     id: int
 
     # All our none if we are requesting data
-    type: int | None
-    len: int | None
-    data: str | None
+    type: int | None = None
+    len: int | None = None
+    data: str | None = None
 
 
 class GenericDP:

--- a/custom_components/wybot/wybot_http_client.py
+++ b/custom_components/wybot/wybot_http_client.py
@@ -32,6 +32,9 @@ DEVICES_URL = "https://api.wybotpool.com/api/group/"
 # Send commands
 COMMAND_URL = "https://api.wybotpool.com/api/device/ao"
 
+# User notification endpoint - may be used for presence registration
+NOTIFICATION_URL = "https://api.wybotpool.com/api/user/notification"
+
 DEFAULT_HEADER = {
     "Content-Type": "application/json",
     "User-Agent": "WYBOT/13 CFNetwork/1498.700.2 Darwin/23.6.0",
@@ -116,17 +119,23 @@ class WyBotHTTPClient:
                     json_response = response.json()
                     response.close()
                     return LoginResponse(**json_response)
+                _LOGGER.warning(
+                    "Login attempt %d failed with status %d: %s",
+                    attempt + 1,
+                    response.status_code,
+                    response.text,
+                )
+                response.close()
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(delay)
+                    delay = min(delay * 2, MAX_RETRY_DELAY)
                 else:
-                    _LOGGER.warning("Login attempt %d failed with status %d: %s",
-                                  attempt + 1, response.status_code, response.text)
-                    response.close()
-                    if attempt < MAX_RETRIES - 1:
-                        time.sleep(delay)
-                        delay = min(delay * 2, MAX_RETRY_DELAY)
-                    else:
-                        _LOGGER.error("Error getting token after %d attempts: %s",
-                                    MAX_RETRIES, response.text)
-                        return None
+                    _LOGGER.error(
+                        "Error getting token after %d attempts: %s",
+                        MAX_RETRIES,
+                        response.text,
+                    )
+                    return None
             except requests.exceptions.Timeout as err:
                 _LOGGER.warning("Login timeout on attempt %d: %s", attempt + 1, err)
                 if attempt < MAX_RETRIES - 1:
@@ -136,13 +145,16 @@ class WyBotHTTPClient:
                     _LOGGER.error("Login timeout after %d attempts", MAX_RETRIES)
                     return None
             except requests.exceptions.RequestException as err:
-                _LOGGER.warning("Login request error on attempt %d: %s", attempt + 1, err)
+                _LOGGER.warning(
+                    "Login request error on attempt %d: %s", attempt + 1, err
+                )
                 if attempt < MAX_RETRIES - 1:
                     time.sleep(delay)
                     delay = min(delay * 2, MAX_RETRY_DELAY)
                 else:
-                    _LOGGER.error("Error getting token after %d attempts: %s",
-                                MAX_RETRIES, err)
+                    _LOGGER.error(
+                        "Error getting token after %d attempts: %s", MAX_RETRIES, err
+                    )
                     return None
             except Exception as err:
                 _LOGGER.error("Unexpected error during login: %s", err)
@@ -177,29 +189,36 @@ class WyBotHTTPClient:
                     json_response = response.json()
                     response.close()
                     return DevicesResponse(**json_response)
-                elif response.status_code == 401:
+                if response.status_code == 401:
                     # Token expired, try to refresh
                     _LOGGER.info("Token expired, refreshing authentication")
                     response.close()
                     if self.authenticate():
                         # Retry immediately after re-auth
                         continue
-                    else:
-                        _LOGGER.error("Failed to refresh token after 401")
-                        return None
+                    _LOGGER.error("Failed to refresh token after 401")
+                    return None
+                _LOGGER.warning(
+                    "Get devices attempt %d failed with status %d: %s",
+                    attempt + 1,
+                    response.status_code,
+                    response.text,
+                )
+                response.close()
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(delay)
+                    delay = min(delay * 2, MAX_RETRY_DELAY)
                 else:
-                    _LOGGER.warning("Get devices attempt %d failed with status %d: %s",
-                                  attempt + 1, response.status_code, response.text)
-                    response.close()
-                    if attempt < MAX_RETRIES - 1:
-                        time.sleep(delay)
-                        delay = min(delay * 2, MAX_RETRY_DELAY)
-                    else:
-                        _LOGGER.error("Error getting devices after %d attempts: %s",
-                                    MAX_RETRIES, response.text)
-                        return None
+                    _LOGGER.error(
+                        "Error getting devices after %d attempts: %s",
+                        MAX_RETRIES,
+                        response.text,
+                    )
+                    return None
             except requests.exceptions.Timeout as err:
-                _LOGGER.warning("Get devices timeout on attempt %d: %s", attempt + 1, err)
+                _LOGGER.warning(
+                    "Get devices timeout on attempt %d: %s", attempt + 1, err
+                )
                 if attempt < MAX_RETRIES - 1:
                     time.sleep(delay)
                     delay = min(delay * 2, MAX_RETRY_DELAY)
@@ -207,13 +226,16 @@ class WyBotHTTPClient:
                     _LOGGER.error("Get devices timeout after %d attempts", MAX_RETRIES)
                     return None
             except requests.exceptions.RequestException as err:
-                _LOGGER.warning("Get devices request error on attempt %d: %s", attempt + 1, err)
+                _LOGGER.warning(
+                    "Get devices request error on attempt %d: %s", attempt + 1, err
+                )
                 if attempt < MAX_RETRIES - 1:
                     time.sleep(delay)
                     delay = min(delay * 2, MAX_RETRY_DELAY)
                 else:
-                    _LOGGER.error("Error getting devices after %d attempts: %s",
-                                MAX_RETRIES, err)
+                    _LOGGER.error(
+                        "Error getting devices after %d attempts: %s", MAX_RETRIES, err
+                    )
                     return None
             except Exception as err:
                 _LOGGER.error("Unexpected error getting devices: %s", err)
@@ -227,3 +249,42 @@ class WyBotHTTPClient:
         if response is None:
             return {}
         return {group.id: group for group in response.metadata.groups}
+
+    def register_presence(self) -> bool:
+        """Register presence with the cloud server.
+
+        This signals to the WyBot cloud that we're actively listening,
+        which may help ensure MQTT messages are relayed when devices come online.
+        Note: Devices still need to be woken up via the mobile app's BLE connection.
+        """
+        if not self._refresh_token_if_needed():
+            _LOGGER.debug("Failed to refresh token for presence registration")
+            return False
+
+        if self._user_id is None:
+            _LOGGER.debug("User ID not set for presence registration")
+            return False
+
+        # POST to notification endpoint with userId to register presence
+        try:
+            response = self._session.post(
+                NOTIFICATION_URL,
+                headers={**DEFAULT_HEADER, "Authorization": f"token {self._token}"},
+                json={"userId": self._user_id},
+                allow_redirects=False,
+                timeout=TIMEOUT,
+            )
+            success = response.status_code == 200
+            if success:
+                _LOGGER.debug("Presence registered successfully with cloud server")
+            else:
+                _LOGGER.debug(
+                    "Presence registration response: status=%d, body=%s",
+                    response.status_code,
+                    response.text[:200] if response.text else "empty",
+                )
+            response.close()
+            return success
+        except Exception as err:
+            _LOGGER.debug("Presence registration failed: %s", err)
+            return False

--- a/custom_components/wybot/wybot_models.py
+++ b/custom_components/wybot/wybot_models.py
@@ -134,6 +134,7 @@ class Docker(pydantic_v1.BaseModel):
     device_status: str = pydantic_v1.Field(alias="deviceStatus")
     docker_status: str = pydantic_v1.Field(alias="dockerStatus")
     schedule: str | None = pydantic_v1.Field(alias="schedule")
+    version: Version | None = None
 
     "Extra added fields"
     online: bool = False

--- a/custom_components/wybot/wybot_models.py
+++ b/custom_components/wybot/wybot_models.py
@@ -2,9 +2,12 @@
 
 from typing import TypeVar
 
-from pydantic import v1 as pydantic_v1
+from pydantic import BaseModel, ConfigDict, Field
 
 from .wybot_dp_models import DP, GenericDP, wybot_dp_id
+
+
+T = TypeVar("T", bound=GenericDP)
 
 
 def to_snake_case(string: str) -> str:
@@ -20,7 +23,7 @@ def to_snake_case(string: str) -> str:
     return "".join(["_" + i.lower() if i.isupper() else i for i in string]).lstrip("_")
 
 
-class Command(pydantic_v1.BaseModel):
+class Command(BaseModel):
     """Represents a command to be sent or received from a device."""
 
     # 4 - Send Write Command
@@ -30,37 +33,35 @@ class Command(pydantic_v1.BaseModel):
     dp: list[DP]
     ts: int
 
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
+
     def get_dps_as_keyed_dict(self) -> dict[str, GenericDP]:
         """Return the DP list as a keyed dictionary."""
         return {str(dp.id): wybot_dp_id.get(dp.id, GenericDP)(dp) for dp in self.dp}
 
-    class Config:
-        """Represents the configuration options for the class."""
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
-
-
-class LoginMetadata(pydantic_v1.BaseModel):
+class LoginMetadata(BaseModel):
     """Represents the metadata for a user."""
 
-    user_id: str = pydantic_v1.Field(alias="userId")
+    user_id: str = Field(alias="userId")
     token: str
     username: str
     name: str
     avatar: str
     groupid: int
-    reg_time: int = pydantic_v1.Field(alias="regTime")
-    last_login_time: int = pydantic_v1.Field(alias="lastLoginTime")
+    reg_time: int = Field(alias="regTime")
+    last_login_time: int = Field(alias="lastLoginTime")
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class LoginResponse(pydantic_v1.BaseModel):
+class LoginResponse(BaseModel):
     """Represents the response for a login operation."""
 
     code: int
@@ -69,34 +70,37 @@ class LoginResponse(pydantic_v1.BaseModel):
     metadata: LoginMetadata | None = None
 
 
-class Version(pydantic_v1.BaseModel):
+class Version(BaseModel):
     """Represents the firmware version information for a device."""
 
-    firmware: str | None = pydantic_v1.Field(alias="Firmware")
+    firmware: str | None = Field(default=None, alias="Firmware")
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class Device(pydantic_v1.BaseModel):
+class Device(BaseModel):
     """Represents a device's information including identifiers, type, and version."""
 
-    device_id: str = pydantic_v1.Field(alias="deviceId")
-    device_name: str = pydantic_v1.Field(alias="deviceName")
-    device_type: str = pydantic_v1.Field(alias="deviceType")
-    ble_name: str = pydantic_v1.Field(alias="bleName")
+    device_id: str = Field(alias="deviceId")
+    device_name: str = Field(alias="deviceName")
+    device_type: str = Field(alias="deviceType")
+    ble_name: str = Field(alias="bleName")
     version: Version | None = None
-    pool_id: str | None = pydantic_v1.Field(alias="poolId")
-    auto_update: str = pydantic_v1.Field(alias="autoUpdate")
+    pool_id: str | None = Field(default=None, alias="poolId")
+    auto_update: str = Field(alias="autoUpdate")
 
     "Extra added fields"
     online: bool = False
     dps: dict[str, DP] = {}
 
-    T = TypeVar("T", bound=GenericDP)
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
     def get_dp(self, cls: type[T]) -> T | None:
         """Get the specified DP from the device.
@@ -117,37 +121,27 @@ class Device(pydantic_v1.BaseModel):
                 return dp
         return None
 
-    class Config:
-        """Represents the configuration options for the class."""
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-
-
-class Docker(pydantic_v1.BaseModel):
+class Docker(BaseModel):
     """Represents a Docker container's information including identifiers, status, and schedule."""
 
-    docker_id: str = pydantic_v1.Field(alias="dockerId")
-    docker_type: str = pydantic_v1.Field(alias="dockerType")
-    ble_name: str = pydantic_v1.Field(alias="bleName")
-    device_status: str = pydantic_v1.Field(alias="deviceStatus")
-    docker_status: str = pydantic_v1.Field(alias="dockerStatus")
-    schedule: str | None = pydantic_v1.Field(alias="schedule")
+    docker_id: str = Field(alias="dockerId")
+    docker_type: str = Field(alias="dockerType")
+    ble_name: str = Field(alias="bleName")
+    device_status: str = Field(alias="deviceStatus")
+    docker_status: str = Field(alias="dockerStatus")
+    schedule: str | None = Field(default=None, alias="schedule")
     version: Version | None = None
 
     "Extra added fields"
     online: bool = False
     dps: dict[str, DP] = {}
 
-    class Config:
-        """Represents the configuration options for the class."""
-
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-
-    T = TypeVar("T", bound=GenericDP)
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
     def get_dp(self, cls: type[T]) -> T | None:
         """Get the specified DP from the device.
@@ -169,41 +163,37 @@ class Docker(pydantic_v1.BaseModel):
         return None
 
 
-class Vision(pydantic_v1.BaseModel):
+class Vision(BaseModel):
     """Represents vision-related information including privacy settings, logs, and media."""
 
-    vision_id: str | None = pydantic_v1.Field(alias="visionId")
+    vision_id: str | None = Field(default=None, alias="visionId")
     privacy: bool
-    log: str | None
-    video: str | None
-    picture: str | None
+    log: str | None = None
+    video: str | None = None
+    picture: str | None = None
     policy: bool
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class Group(pydantic_v1.BaseModel):
+class Group(BaseModel):
     """Represents a group containing Docker, Device, and Vision information."""
 
-    docker: Docker | None
+    docker: Docker | None = None
     device: Device
     vision: Vision
     name: str
     id: str
-    auto_update: str = pydantic_v1.Field(alias="autoUpdate")
+    auto_update: str = Field(alias="autoUpdate")
 
-    class Config:
-        """Represents the configuration options for the class."""
-
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
-        arbitrary_types_allowed = True
-
-    T = TypeVar("T", bound=GenericDP)
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
 
     def get_dp(self, cls: type[T]) -> T | None:
         if not issubclass(cls, GenericDP):
@@ -220,19 +210,18 @@ class Group(pydantic_v1.BaseModel):
         return None
 
 
-class DeviceMetadata(pydantic_v1.BaseModel):
+class DeviceMetadata(BaseModel):
     """Represents metadata containing a list of groups."""
 
     groups: list[Group]
 
-    class Config:
-        """Represents the configuration options for the class."""
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )
 
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
 
-
-class DevicesResponse(pydantic_v1.BaseModel):
+class DevicesResponse(BaseModel):
     """Represents the API response for devices containing status code, reason, message, and metadata."""
 
     code: int
@@ -240,8 +229,7 @@ class DevicesResponse(pydantic_v1.BaseModel):
     message: str
     metadata: DeviceMetadata
 
-    class Config:
-        """Represents the configuration options for the class."""
-
-        alias_generator = to_snake_case
-        allow_population_by_field_name = True
+    model_config = ConfigDict(
+        alias_generator=to_snake_case,
+        populate_by_name=True,
+    )

--- a/custom_components/wybot/wybot_mqtt_client.py
+++ b/custom_components/wybot/wybot_mqtt_client.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import json
 import logging
 import time
+import uuid
 
 import paho.mqtt.client as mqtt
 
@@ -46,7 +47,11 @@ class WyBotMQTTClient:
 
     def __init__(self, on_message: Callable) -> None:
         """Init the wybot mqtt api."""
-        self._mqtt = mqtt.Client()
+        # Generate a UUID-based client ID like mobile apps use
+        # Format: wybot-{uuid} to mimic app behavior
+        client_id = f"wybot-{uuid.uuid4()}"
+        _LOGGER.debug("MQTT client ID: %s", client_id)
+        self._mqtt = mqtt.Client(client_id=client_id, clean_session=True)
         self._mqtt.username_pw_set(USERNAME, PASWORD)
         self._mqtt.on_connect = self.on_connect
         self._mqtt.on_message = self.on_message
@@ -176,9 +181,9 @@ class WyBotMQTTClient:
             # Re-subscribe to all topics
             for subscription in self._subscriptions:
                 client.subscribe(subscription)
-            # Note: Don't query devices here - wait for will messages to arrive
-            # The coordinator will trigger queries when devices come online
-            # This matches iOS app behavior
+            # Request status updates for all devices
+            for device in self._devices:
+                self.ensure_device_sends_statuses(device)
             # Signal connection event
             if self._connection_event:
                 self._connection_event.set()
@@ -206,126 +211,43 @@ class WyBotMQTTClient:
         if rc != 0:
             _LOGGER.info("Unexpected disconnection, will attempt to reconnect")
 
-    def subscribe_for_device_initial(self, device_id):
-        """Subscribe to initial topics for a device (will and OTA notifications).
-
-        This matches the iOS app pattern: subscribe to will/OTA topics first,
-        before sending any queries.
-        """
-        _LOGGER.debug(f"Subscribing to initial topics for device {device_id}")
-        initial_topics = [
-            f"/will/{device_id}",
-            f"/device/OTA/notify_ready_to_update/{device_id}",
-        ]
-        for topic in initial_topics:
-            if topic not in self._subscriptions:
-                self._subscriptions.append(topic)
-            self._mqtt.subscribe(topic)
-        if device_id not in self._devices:
-            self._devices.append(device_id)
-
     def subscribe_for_device(self, device_id):
-        """Subscribe to response topics for a device.
-
-        This is called after the initial query is sent, matching iOS app pattern.
-        """
-        _LOGGER.debug(f"Subscribing to response topics for device {device_id}")
-        response_topics = [
-            f"/device/DATA/send_transparent_data/{device_id}",
-            f"/device/OTA/post_update_progress/{device_id}",
-            f"/device/DATA/recv_transparent_query_data/{device_id}",
-            f"/device/DATA/recv_transparent_cmd_data/{device_id}",
-        ]
-        for topic in response_topics:
-            if topic not in self._subscriptions:
-                self._subscriptions.append(topic)
-            self._mqtt.subscribe(topic)
+        """Subscribe to a device."""
+        _LOGGER.debug(f"Subscribing to wybot mqtt for device {device_id}")
+        self._subscriptions.append(f"/will/{device_id}")
+        self._subscriptions.append(f"/device/DATA/send_transparent_data/{device_id}")
+        self._subscriptions.append(
+            f"/device/DATA/recv_transparent_query_data/{device_id}"
+        )
+        self._subscriptions.append(
+            f"/device/DATA/recv_transparent_cmd_data/{device_id}"
+        )
+        self._subscriptions.append(f"/device/OTA/post_update_progress/{device_id}")
+        self._subscriptions.append(f"/device/OTA/notify_ready_to_update/{device_id}")
+        self._devices.append(device_id)
+        for subscription in self._subscriptions:
+            self._mqtt.subscribe(subscription)
+        self.ensure_device_sends_statuses(device_id)
 
     def ensure_device_sends_statuses(self, deviceId: str):
-        """Ensure that a device sends statuses (sync version).
-
-        Sends all queries immediately. For async version with delays, use
-        ensure_device_sends_statuses_async.
-        """
+        """Ensure that a device sends statuses."""
         _LOGGER.debug(f"Ensuring device sends statuses {deviceId}")
+
         # Query DPs individually in the exact order the iOS app uses
         # iOS app queries: 1, 79, 1, 0, 77 (DP 1 is queried twice)
-        # We also include 50 and 11 for our own needs
-        query_dps = [1, 79, 1, 0, 77, 50, 11]
+        # We also include: 50 (battery), 11 (dock), and solar dock DPs
+        # Solar dock DPs: 131 (energy), 221 (dock battery), 222 (solar status), 214 (dock type)
+        # S2 Pro additional DPs: 209, 212, 213
+        query_dps = [0, 1, 79, 1, 0, 77, 50, 11, 131, 209, 212, 213, 214, 221, 222]
         for dp_id in query_dps:
             self.send_query_command_for_device(
                 deviceId,
                 {
-                    "ts": time.time(),
+                    "ts": int(time.time()),
                     "cmd": 9,
                     "dp": [{"id": dp_id}],
                 },
             )
-
-    def send_initial_query(self, deviceId: str):
-        """Send the initial query (DP 1 only) matching iOS app pattern.
-
-        The iOS app sends only DP 1 query first, before subscribing to
-        response topics.
-        """
-        _LOGGER.debug(f"Sending initial query (DP 1) for device {deviceId}")
-        self.send_query_command_for_device(
-            deviceId,
-            {
-                "ts": time.time(),
-                "cmd": 9,
-                "dp": [{"id": 1}],
-            },
-        )
-
-    async def ensure_device_sends_statuses_async(self, deviceId: str):
-        """Ensure that a device sends statuses (async version with delays).
-
-        Sends remaining queries one at a time with delays, matching iOS app behavior.
-        iOS app sends queries with 20-120ms delays between them.
-        This sends queries for DPs: 79, 1, 0, 77, 50, 11 (excluding the initial DP 1).
-        """
-        _LOGGER.debug(f"Ensuring device sends statuses {deviceId} (async with delays)")
-        # Query DPs individually in the exact order the iOS app uses
-        # iOS app queries: 79, 1, 0, 77 (after initial DP 1 query)
-        # We also include 50 and 11 for our own needs
-        # iOS app sends queries with 20-120ms delays between them
-        query_dps = [79, 1, 0, 77, 50, 11]
-        for dp_id in query_dps:
-            self.send_query_command_for_device(
-                deviceId,
-                {
-                    "ts": time.time(),
-                    "cmd": 9,
-                    "dp": [{"id": dp_id}],
-                },
-            )
-            # Add delay between queries to match iOS app behavior (20-120ms)
-            # Use 50ms as a middle ground
-            await asyncio.sleep(0.05)  # 50ms delay
-
-    async def query_device_ios_pattern(self, deviceId: str):
-        """Query device using iOS app pattern.
-
-        Since response topics are already subscribed upfront, this just sends queries:
-        1. Send initial query (DP 1)
-        2. Wait briefly
-        3. Send remaining queries with delays
-        """
-        _LOGGER.debug(f"Querying device {deviceId} using iOS app pattern")
-        if not self.is_connected():
-            _LOGGER.debug("Not connected, cannot query device")
-            return
-
-        # Step 1: Send initial query (DP 1 only)
-        self.send_initial_query(deviceId)
-
-        # Step 2: Wait briefly (50-100ms) before sending remaining queries
-        # This matches iOS app timing
-        await asyncio.sleep(0.075)  # 75ms delay
-
-        # Step 3: Send remaining queries with delays
-        await self.ensure_device_sends_statuses_async(deviceId)
 
     def send_query_command_for_device(self, device_id: str, command: dict):
         """Send a query command to a device."""

--- a/docs/BLUETOOTH_PROTOCOL.md
+++ b/docs/BLUETOOTH_PROTOCOL.md
@@ -1,0 +1,927 @@
+# WyBot Bluetooth (BLE) Protocol Documentation
+
+This document describes the Bluetooth Low Energy (BLE) protocol used by WyBot pool cleaning robots, based on reverse engineering of the WyBot Android APK and live device testing.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Device Discovery](#device-discovery)
+3. [Service UUIDs](#service-uuids)
+4. [Connection Protocol](#connection-protocol)
+5. [Message Format](#message-format)
+6. [Data Points (DPs) Reference](#data-points-dps-reference)
+7. [BLE Response Parsing](#ble-response-parsing)
+8. [Implementation Notes](#implementation-notes)
+9. [Testing Guide](#testing-guide)
+
+---
+
+## Overview
+
+WyBot pool robots support two communication methods:
+
+| Method | Use Case | Range | Latency |
+|--------|----------|-------|---------|
+| **MQTT** | Cloud communication, remote control | Unlimited (internet) | ~1-2s |
+| **BLE** | Local wake-up, direct commands | ~10m | ~100ms |
+
+### Communication Architecture
+
+```
+┌─────────────┐      BLE        ┌─────────────┐
+│  HA/Phone   │◄───────────────►│ WyBot Robot │
+└─────────────┘                 └──────┬──────┘
+       │                               │
+       │ MQTT                          │ WiFi
+       │                               │
+       ▼                               ▼
+┌─────────────────────────────────────────────┐
+│           mqtt.wybotpool.com                │
+└─────────────────────────────────────────────┘
+```
+
+### BLE Primary Use Cases
+
+1. **Wake device**: Establish BLE connection to wake the robot from sleep mode
+2. **Direct commands**: Send cleaning commands via BLE when MQTT is unavailable
+3. **WiFi configuration**: Configure WiFi credentials on new/reset devices
+4. **Status polling**: Query device status directly without cloud dependency
+
+---
+
+## Device Discovery
+
+### BLE Advertisement Name Format
+
+WyBot devices advertise using their MAC address without colons:
+
+| Device | BLE Name Example | MAC Address |
+|--------|------------------|-------------|
+| S2 Pro Robot | `CCBA97932A96` | `CC:BA:97:93:2A:96` |
+| DS20 Solar Dock | `3C8427565A1A` | `3C:84:27:56:5A:1A` |
+
+### Scanning for Devices
+
+```python
+from homeassistant.components.bluetooth import async_discovered_service_info
+
+# Scan for WyBot devices
+service_infos = async_discovered_service_info(hass, connectable=True)
+for info in service_infos:
+    device = info.device
+    # Check if name matches MAC pattern (12 hex characters)
+    if device.name and len(device.name) == 12:
+        if all(c in '0123456789ABCDEFabcdef' for c in device.name):
+            print(f"Found WyBot device: {device.name} at {device.address}")
+```
+
+### Converting BLE Name to MAC Address
+
+```python
+def ble_name_to_mac(ble_name: str) -> str:
+    """Convert BLE name (CCBA97932A96) to MAC (CC:BA:97:93:2A:96)."""
+    if len(ble_name) == 12:
+        return ':'.join(ble_name[i:i+2] for i in range(0, 12, 2)).upper()
+    return ble_name
+```
+
+---
+
+## Service UUIDs
+
+### DS20 Solar Dock (Verified via BLE Scan)
+
+> **Architecture Note:** You always send BLE commands to the **DS20 Solar Dock** unless the robot
+> itself is visible via BLE. When the robot is docked, the dock relays commands to the robot.
+> When the robot is out cleaning, it's typically out of BLE range. The dock advertises as
+> `DS20-XXXXXXXXXXXX` (e.g., `DS20-3C8427565A1A`), while the robot advertises as just its MAC
+> address (e.g., `CCBA97932A96`).
+
+| Service | UUID | Description |
+|---------|------|-------------|
+| Service EE | `000000ee-0000-1000-8000-00805f9b34fb` | Primary service |
+| Service FF | `000000ff-0000-1000-8000-00805f9b34fb` | Secondary service |
+
+| Characteristic | UUID | Properties | Purpose |
+|---------------|------|------------|---------|
+| EE01 | `0000ee01-0000-1000-8000-00805f9b34fb` | Read/Write/Notify | **Write commands here** (handle 0x002e) |
+| FF01 | `0000ff01-0000-1000-8000-00805f9b34fb` | Read/Write/Notify | **Enable notifications here** (handle 0x0029) |
+
+> **Note:** Despite both characteristics supporting write, the WyBot app only writes to EE01.
+> Commands written to FF01 are ignored. Status updates are received as notifications on FF01.
+
+### K1/S1/S2 Series (From APK: `k1/AbstractC0300a.java`)
+
+| Service | UUID | Description |
+|---------|------|-------------|
+| Service 1000 | `00001000-0000-1000-8000-00805f9b34fb` | Primary service |
+
+| Characteristic | UUID | Properties | Purpose |
+|---------------|------|------------|---------|
+| 1001 | `00001001-0000-1000-8000-00805f9b34fb` | Write | Command write |
+| 1002 | `00001002-0000-1000-8000-00805f9b34fb` | Notify | Data reception |
+| 1003 | `00001003-0000-1000-8000-00805f9b34fb` | Unknown | Reserved |
+| 1004 | `00001004-0000-1000-8000-00805f9b34fb` | Read | Status read |
+| 1005 | `00001005-0000-1000-8000-00805f9b34fb` | Unknown | Reserved |
+
+### Client Characteristic Configuration Descriptor (CCCD)
+
+| Descriptor | UUID | Purpose |
+|------------|------|---------|
+| CCCD | `00002902-0000-1000-8000-00805f9b34fb` | Enable notifications |
+
+---
+
+## Connection Protocol
+
+### Connection State Machine (From APK: `R1/f.java`)
+
+```
+┌───────────────┐
+│ State 0       │
+│ Disconnected  │
+└───────┬───────┘
+        │ connect()
+        ▼
+┌───────────────┐
+│ State 1       │
+│ Connecting    │
+└───────┬───────┘
+        │ onConnectionStateChange(state=2)
+        ▼
+┌───────────────┐       ┌───────────────┐
+│ State 2       │──────►│ State 3       │
+│ Connected     │       │ Disconnecting │
+└───────────────┘       └───────────────┘
+```
+
+### Wake Sequence
+
+Based on APK analysis, the device wakes when a BLE connection is established:
+
+```python
+async def wake_device(hass, ble_name: str) -> bool:
+    """Wake WyBot device via BLE connection."""
+
+    # Step 1: Convert BLE name to MAC address
+    mac_address = ble_name_to_mac(ble_name)
+
+    # Step 2: Get BLE device from Home Assistant
+    ble_device = async_ble_device_from_address(hass, mac_address, connectable=True)
+    if not ble_device:
+        return False
+
+    # Step 3: Connect (this triggers wake via onConnectionStateChange state=2)
+    client = await establish_connection(BleakClient, ble_device, ble_device.name)
+
+    try:
+        if not client.is_connected:
+            return False
+
+        # Step 4: Discover services (validates connection)
+        services = client.services
+
+        # Step 5: Enable notifications on data characteristic
+        await client.start_notify(CHAR_UUID_EE01, notification_handler)
+
+        # Step 6: Hold connection for 3-5 seconds
+        await asyncio.sleep(5.0)
+
+        # Step 7: Device should now connect to MQTT
+        return True
+
+    finally:
+        await client.disconnect()
+```
+
+### Connection Parameters (From APK: `BleService.java`)
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Max concurrent connections | 4 | Multiple devices supported |
+| Connection timeout | 3000ms | App default, increase for reliability |
+| Reconnect timer | 100ms | Interval on disconnect |
+| Wake hold time | 3-5 seconds | Allow device to fully wake |
+
+---
+
+## Message Format
+
+> **CRITICAL UPDATE (January 2026):** The WyBot mobile app uses **binary AA55 format** for BLE
+> commands, NOT JSON. Commands must be sent to the **EE01** characteristic. This was verified
+> via PacketLogger capture of the iOS app. See [Binary Command Format](#binary-command-format-verified-working)
+> section below for working examples.
+
+### Binary Command Format (VERIFIED WORKING)
+
+The WyBot app sends commands to the **EE01 characteristic** using binary AA55 format:
+
+```
+┌────────┬─────────┬──────────┬───────────────────────────┬──────────┐
+│ Header │   Cmd   │   Len    │        DP Payload         │ Checksum │
+│ AA 55  │  00 04  │  XX XX   │ id + type + len + value   │    XX    │
+│ 2 bytes│ 2 bytes │ 2 bytes  │       N bytes             │  1 byte  │
+└────────┴─────────┴──────────┴───────────────────────────┴──────────┘
+```
+
+**Working Commands (captured from WyBot iOS app and verified):**
+
+| Command | Hex Data | Description |
+|---------|----------|-------------|
+| Start Cleaning | `aa5500040400000401030f` | DP 0 = 03 → Status: Cleaning |
+| Stop Cleaning | `aa5500040400000401010d` | DP 0 = 01 → Status: Stopped (robots without dock) |
+| Return to Dock | `aa55000404000b04010118` | DP 11 = 01 → Status: 04 (Returning) |
+
+**Cleaning Mode Commands (DP 1):**
+
+| Mode | Value | Hex Command |
+|------|-------|-------------|
+| Floor | 00 | `aa5500040400010401000d` |
+| Wall | 01 | `aa5500040400010401010e` |
+| Wall Then Floor | 02 | `aa5500040400010401020f` |
+| Advanced Full Pool | 03 | `aa55000404000104010310` |
+| Water Line | 04 | `aa55000404000104010411` |
+| Turbo Floor | 05 | `aa55000404000104010512` |
+| Eco Floor | 06 | `aa55000404000104010613` |
+
+> **Note:** For robots with a dock (like DS20 Solar Dock), the app only shows "Return to Dock".
+> The Stop command (DP 0 = 01) is for robots without a dock that need to stop in place.
+
+**WiFi Configuration Commands (captured from WyBot app):**
+
+| Step | Cmd | Hex Example | Description |
+|------|-----|-------------|-------------|
+| 1 | 0x2D | `aa55002d020000002e` | WiFi init/reset |
+| 2 | 0x2A | `aa55002a2200[SSID padded to ~34 bytes][checksum]` | Send SSID |
+| 3 | 0x2B | `aa55002b1100[PASSWORD][checksum]` | Send password |
+| 4 | 0x03 | `aa550003000002` | Apply configuration |
+
+> **Note:** SSID is null-padded to a fixed length. Length field is little-endian.
+
+**Query Commands (cmd 0x09):**
+
+To query a DP value, send a binary query command:
+
+```
+Format: aa55 + 0009 + len_le + dp_id + checksum
+Example: aa5500090100010a  (query DP 1 = CleaningMode)
+```
+
+| Query | Hex Command | Description |
+|-------|-------------|-------------|
+| CleaningStatus | `aa55000901000009` | Query DP 0 |
+| CleaningMode | `aa5500090100010a` | Query DP 1 |
+| Battery | `aa550009010032` + checksum | Query DP 50 (0x32) |
+| DockStatus | `aa5500090100d5` + checksum | Query DP 213 (0xd5) |
+
+> **Tip:** Use `build_binary_query(dp_id)` function to generate correct commands with checksums.
+
+```python
+def build_binary_query(dp_id: int) -> bytes:
+    """Build a binary query command for a single DP."""
+    header = b'\xaa\x55'
+    cmd = b'\x00\x09'  # Query command
+    length = b'\x01\x00'  # 1 byte payload, little-endian
+    payload = bytes([dp_id])
+    packet = header + cmd + length + payload
+    checksum = (sum(packet[2:]) - 1) & 0xFF
+    return packet + bytes([checksum])
+```
+
+**Response Types (IMPORTANT):**
+
+The device sends different response types. **Only parse DP data from status broadcasts (cmd=0x05)**:
+
+| Cmd | Name | Description | Contains DPs? |
+|-----|------|-------------|---------------|
+| 0x05 | Status | Status broadcast with DP data | ✅ Yes - parse these |
+| 0x1C | ACK | Acknowledgment only | ❌ No - skip these |
+
+```python
+def handle_notify(sender, data: bytearray):
+    if len(data) < 6:
+        return
+
+    # Check command type
+    cmd = int.from_bytes(data[2:4], 'big')
+
+    if cmd == 0x05:  # Status broadcast - contains DP data
+        payload = data[6:-1]  # Skip header(2) + cmd(2) + len(2), exclude checksum
+        # Parse DPs from payload...
+
+    elif cmd == 0x1c:  # ACK - no data
+        pass  # Skip
+```
+
+**Example responses:**
+```
+ACK:    aa55001c0100001c           (cmd=0x1C, no DP data)
+Status: aa550005380000040103...   (cmd=0x05, contains DPs)
+```
+
+**Cleaning Status Values (DP 0):**
+
+| Value | Status |
+|-------|--------|
+| 01 | Stopped |
+| 02 | Returning (legacy?) |
+| 03 | Cleaning |
+| 04 | Returning to Dock |
+
+**Key Characteristics:**
+
+| What | Characteristic UUID | Handle | Purpose |
+|------|---------------------|--------|---------|
+| Write Commands | EE01 (`0000ee01-...`) | 0x002e | Send commands here |
+| Notifications | FF01 (`0000ff01-...`) | 0x0029 | Receive status updates |
+
+**Python Example:**
+
+```python
+from bleak import BleakClient
+
+CHAR_UUID_EE01 = "0000ee01-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_FF01 = "0000ff01-0000-1000-8000-00805f9b34fb"
+
+# Pre-built commands (verified working)
+CMD_START_CLEANING = bytes.fromhex('aa5500040400000401030f')  # DP 0 = 03
+CMD_STOP_CLEANING = bytes.fromhex('aa5500040400000401010d')   # DP 0 = 01 (robots without dock)
+CMD_RETURN_TO_DOCK = bytes.fromhex('aa55000404000b04010118')  # DP 11 = 01
+
+async def start_cleaning(address: str):
+    async with BleakClient(address) as client:
+        await client.write_gatt_char(CHAR_UUID_EE01, CMD_START_CLEANING, response=True)
+        # Status will change to 03 (Cleaning)
+
+async def stop_cleaning(address: str):
+    """Stop cleaning in place (for robots without a dock)."""
+    async with BleakClient(address) as client:
+        await client.write_gatt_char(CHAR_UUID_EE01, CMD_STOP_CLEANING, response=True)
+        # Status will change to 01 (Stopped)
+
+async def return_to_dock(address: str):
+    async with BleakClient(address) as client:
+        await client.write_gatt_char(CHAR_UUID_EE01, CMD_RETURN_TO_DOCK, response=True)
+        # Status will change to 04 (Returning to Dock)
+```
+
+**Building Custom Binary Commands:**
+
+```python
+def build_binary_command(cmd: int, dp_id: int, dp_type: int, dp_len: int, dp_value: bytes) -> bytes:
+    """Build a binary AA55 format command for BLE."""
+    dp_data = bytes([dp_id, dp_type, dp_len]) + dp_value
+    header = b'\xaa\x55'
+    cmd_bytes = cmd.to_bytes(2, 'big')  # 0x0004 for write
+    payload_len = len(dp_data).to_bytes(2, 'big')
+    packet = header + cmd_bytes + payload_len + dp_data
+    checksum = sum(packet[2:]) & 0xFF
+    return packet + bytes([checksum])
+
+# Example: Build start cleaning command
+start_cmd = build_binary_command(
+    cmd=4,          # Write command
+    dp_id=0,        # CleaningStatus
+    dp_type=4,      # Enum
+    dp_len=1,       # 1 byte
+    dp_value=b'\x03'  # Cleaning
+)
+# Result: aa5500040400000401030f
+```
+
+---
+
+### JSON Command Format (MQTT Only)
+
+**Note:** JSON format works for MQTT but NOT for BLE commands. For BLE, use the binary format above.
+
+For MQTT, WyBot uses JSON commands:
+
+```json
+{
+  "ts": 1705600000,
+  "cmd": 4,
+  "dp": [
+    {
+      "id": 0,
+      "type": 4,
+      "len": 1,
+      "data": "03"
+    }
+  ]
+}
+```
+
+### Command Types (`cmd`)
+
+| cmd | Name | Description | Direction |
+|-----|------|-------------|-----------|
+| 4 | Write | Set a DP value | App -> Device |
+| 5 | Response | Status report / acknowledgment | Device -> App |
+| 9 | Query | Request DP value(s) | App -> Device |
+
+### Data Types (`type`)
+
+| Type | Name | Format | Example |
+|------|------|--------|---------|
+| 0 | Raw | Hex string, variable length | `"0164"` (battery: charging, 100%) |
+| 2 | 32-bit | 4 bytes, little-endian | `"e8030000"` (1000 in decimal) |
+| 4 | Enum | 1 byte value as hex | `"03"` (cleaning) |
+| 5 | String | Hex-encoded ASCII string | `"48656c6c6f"` ("Hello") |
+
+### Building Commands
+
+```python
+import json
+import time
+
+def build_write_command(dp_id: int, dp_type: int, dp_len: int, dp_data: str) -> bytes:
+    """Build a write command (cmd=4)."""
+    cmd = {
+        "ts": int(time.time()),
+        "cmd": 4,
+        "dp": [{"id": dp_id, "type": dp_type, "len": dp_len, "data": dp_data}]
+    }
+    return json.dumps(cmd, separators=(',', ':')).encode()
+
+def build_query_command(dp_ids: list[int] | None = None) -> bytes:
+    """Build a query command (cmd=9)."""
+    cmd = {
+        "ts": int(time.time()),
+        "cmd": 9,
+        "dp": [{"id": dp_id} for dp_id in (dp_ids or [])]
+    }
+    return json.dumps(cmd, separators=(',', ':')).encode()
+
+# Example: Start cleaning
+start_cleaning = build_write_command(dp_id=0, dp_type=4, dp_len=1, dp_data="03")
+# Result: {"ts":1705600000,"cmd":4,"dp":[{"id":0,"type":4,"len":1,"data":"03"}]}
+
+# Example: Query all status
+query_all = build_query_command([0, 1, 50, 11])
+# Result: {"ts":1705600000,"cmd":9,"dp":[{"id":0},{"id":1},{"id":50},{"id":11}]}
+```
+
+---
+
+## Data Points (DPs) Reference
+
+### Robot Control DPs
+
+| DP ID | Name | Type | Len | Values | Direction |
+|-------|------|------|-----|--------|-----------|
+| 0 | CleaningStatus | 4 | 1 | `01`=Stopped, `02`=Returning, `03`=Cleaning | R/W |
+| 1 | CleaningMode | 4 | 1 | `00`-`06` (see modes below) | R/W |
+| 11 | Dock | 4 | 1-2 | `01`=Return to dock | R/W |
+| 50 | Battery | 0 | 2 | `[charge_state][level%]` | R |
+| 77 | CleaningLog | - | 36 | Map/log data (binary) | R |
+| 79 | Schedule | 2 | 12 | Schedule configuration | R/W |
+
+### Cleaning Modes (DP 1)
+
+| Value | Mode |
+|-------|------|
+| `00` | Floor |
+| `01` | Wall |
+| `02` | Wall Then Floor |
+| `03` | Advanced Full Pool |
+| `04` | Water Line |
+| `05` | Turbo Floor |
+| `06` | Eco Floor |
+
+### Battery Format (DP 50)
+
+```
+Data: "0164" = [01][64]
+       ↑     ↑
+       │     └─ Battery level: 0x64 = 100%
+       └─ Charge state: 00=Not plugged, 01=Charging, 02=Charged
+```
+
+### Device Status DPs
+
+| DP ID | Name | Type | Len | Values | Direction |
+|-------|------|------|-----|--------|-----------|
+| 209 | DeviceStatus | 4 | 1 | Status flag | R |
+| 212 | ConnectionStatus | 4 | 1 | `01`=Connected | R |
+| 213 | DockConnectionStatus | 4 | 1 | `01`=Docked | R |
+| 214 | DockInfo | 4 | 1 | `01`=Standard, `05`=Solar | R |
+
+### Solar Dock DPs (DS20)
+
+| DP ID | Name | Type | Len | Values | Direction |
+|-------|------|------|-----|--------|-----------|
+| 131 | SolarEnergyHarvested | 2 | 4 | Wh (little-endian) | R |
+| 221 | SolarDockBattery | 0 | 3 | 3-byte format (see below) | R |
+| 222 | SolarStatus | 0 | 1 | `01`=Charging | R |
+| 223 | Unknown | - | 4 | Unknown | R |
+
+### Solar Energy Format (DP 131)
+
+```python
+def parse_solar_energy(data: str) -> int:
+    """Parse solar energy harvested in Wh (little-endian)."""
+    # data = "e8030000" = 1000 Wh
+    return int.from_bytes(bytes.fromhex(data), byteorder="little")
+```
+
+### Solar Dock Battery Format (DP 221)
+
+3-byte format: `XXYYZZ`
+- `XX`: Status/flags byte (typically `01`)
+- `YY`: Battery percentage (0-100)
+- `ZZ`: Unknown (possibly voltage related, typically `0a`)
+
+```python
+def parse_solar_battery(data: str) -> int:
+    """Parse solar dock battery percentage from 3-byte format."""
+    # data = "01480a" -> byte 1 = "48" = 72%
+    # data = "01470a" -> byte 1 = "47" = 71%
+    return int(data[2:4], 16)
+```
+
+---
+
+## BLE Response Parsing
+
+### Response Formats
+
+WyBot BLE responses use a **binary format** (not JSON like MQTT). This was verified through live device testing.
+
+#### Binary Response Format (Verified)
+
+```
+┌────────┬─────────┬─────────┬────────────┬──────────┐
+│ Header │ Version │   Cmd   │   Length   │ Payload  │ Checksum │
+│ AA 55  │   00    │   05    │  XX XX     │ DP Data  │    XX    │
+│ 2 bytes│ 1 byte  │ 1 byte  │ 2 bytes BE │ N bytes  │  1 byte  │
+└────────┴─────────┴─────────┴────────────┴──────────┴──────────┘
+```
+
+**Command Codes (verified):**
+| Cmd | Name | Description |
+|-----|------|-------------|
+| 0x05 | Status | Status response with DP data |
+| 0x12 | DeviceInfo | Device pairing/info (contains device IDs, MACs) |
+| 0x1C | Ack | Acknowledgment |
+
+### Binary DP Data Format (Verified)
+
+Each DP entry in the payload:
+
+```
+┌─────────┬──────┬────────┬───────────┐
+│  DP ID  │ Type │ Length │   Data    │
+│ 1 byte  │1 byte│ 1 byte │ len bytes │
+└─────────┴──────┴────────┴───────────┘
+```
+
+**Example parsed from live DS20 Solar Dock:**
+```
+Raw: aa550005380000040101320002012c83020433783900...
+
+Parsed DPs:
+  DP   0 (CleaningStatus): type=4, len=1, data=01 -> Stopped
+  DP  50 (Battery):        type=0, len=2, data=012c -> 44%, Charging
+  DP 131 (SolarEnergy):    type=2, len=4, data=33783900 -> 3,766,323 Wh
+  DP 214 (DockInfo):       type=4, len=1, data=05 -> Solar dock
+  DP 222 (SolarStatus):    type=0, len=1, data=01 -> Charging
+```
+
+### Parsing Code
+
+```python
+def parse_ble_response(data: bytes) -> list[dict]:
+    """Parse BLE response containing DP data."""
+    dps = []
+
+    if len(data) < 7:
+        return dps
+
+    # Check for header
+    if data[:2] == b'\xaa\x55':
+        # WyBot format: aa55 + cmd(2) + len(2) + data + checksum
+        payload_len = (data[4] << 8) | data[5]
+        offset = 6
+        end_offset = min(6 + payload_len, len(data) - 1)
+    elif data[:2] == b'\x55\xaa':
+        # Tuya format: 55aa + version + cmd + len(2) + data
+        offset = 6
+        end_offset = len(data) - 1
+    else:
+        # Try as raw DP data
+        offset = 0
+        end_offset = len(data)
+
+    # Parse DP entries
+    while offset < end_offset - 2:
+        dp_id = data[offset]
+        dp_type = data[offset + 1]
+        dp_len = data[offset + 2]
+        dp_data_start = offset + 3
+
+        if dp_data_start + dp_len > end_offset:
+            break
+
+        dp_data = data[dp_data_start:dp_data_start + dp_len].hex()
+        dps.append({
+            "id": dp_id,
+            "type": dp_type,
+            "len": dp_len,
+            "data": dp_data
+        })
+
+        offset = dp_data_start + dp_len
+
+    return dps
+```
+
+---
+
+## Implementation Notes
+
+### Write Types (From APK: `B2/p.java`)
+
+| Write Type | Property | Description |
+|------------|----------|-------------|
+| 1 | `property & 4` | Write without response |
+| 2 | Default | Standard write with response |
+| 4 | `property & 64` | Signed write |
+
+### MTU Considerations
+
+- Default MTU: 23 bytes (20 bytes payload)
+- Negotiate higher MTU for longer payloads
+- JSON commands can exceed 20 bytes; use MTU negotiation or chunking
+
+### Encryption (Optional)
+
+The APK references `libhy_api.so` for encryption, but this library was not present in the analyzed APK version. Encryption may be:
+- Optional feature for newer devices
+- Used only for certain sensitive operations
+- Not implemented in current firmware
+
+The `f5354j` flag in the APK controls whether `decodeMessage()` is called on received data.
+
+### Error Handling
+
+```python
+# Connection errors
+try:
+    client = await establish_connection(BleakClient, device, name)
+except BleakError as err:
+    if "timeout" in str(err).lower():
+        # Connection attempt may still have woken device
+        return True
+    raise
+
+# Write errors
+try:
+    await client.write_gatt_char(char_uuid, payload, response=True)
+except BleakError:
+    # Try write without response as fallback
+    await client.write_gatt_char(char_uuid, payload, response=False)
+```
+
+---
+
+## Testing Guide
+
+### Using Home Assistant Bluetooth Integration
+
+Home Assistant's Bluetooth integration supports:
+- Local Bluetooth adapters
+- ESPHome Bluetooth proxies
+- Shelly BLE proxies
+
+### Service Discovery Script
+
+```python
+import asyncio
+from bleak import BleakClient, BleakScanner
+
+async def discover_services(address: str):
+    """Discover and print all services/characteristics."""
+    async with BleakClient(address) as client:
+        print(f"Connected to {address}")
+
+        for service in client.services:
+            print(f"\nService: {service.uuid}")
+            for char in service.characteristics:
+                print(f"  Characteristic: {char.uuid}")
+                print(f"    Properties: {char.properties}")
+                for desc in char.descriptors:
+                    print(f"    Descriptor: {desc.uuid}")
+
+# Run: asyncio.run(discover_services("CC:BA:97:93:2A:96"))
+```
+
+### Notification Capture Script
+
+```python
+async def capture_notifications(address: str, char_uuid: str, duration: int = 30):
+    """Capture BLE notifications for analysis."""
+    notifications = []
+
+    def handler(sender, data):
+        notifications.append({
+            "time": time.time(),
+            "sender": sender,
+            "data": data.hex()
+        })
+        print(f"Notification: {data.hex()}")
+
+    async with BleakClient(address) as client:
+        await client.start_notify(char_uuid, handler)
+        await asyncio.sleep(duration)
+        await client.stop_notify(char_uuid)
+
+    return notifications
+```
+
+### Command Test Sequence
+
+1. **Connect and enable notifications**
+2. **Send query command**: `{"ts":...,"cmd":9,"dp":[{"id":0},{"id":50}]}`
+3. **Wait for response** (notification or polling)
+4. **Parse response** and verify DP values
+5. **Send write command**: `{"ts":...,"cmd":4,"dp":[{"id":0,"type":4,"len":1,"data":"03"}]}`
+6. **Verify acknowledgment** (cmd=5 response)
+
+---
+
+## Appendix: Quick Reference
+
+### Common Commands
+
+```python
+# Start cleaning
+{"ts":T,"cmd":4,"dp":[{"id":0,"type":4,"len":1,"data":"03"}]}
+
+# Stop cleaning
+{"ts":T,"cmd":4,"dp":[{"id":0,"type":4,"len":1,"data":"01"}]}
+
+# Return to dock
+{"ts":T,"cmd":4,"dp":[{"id":11,"type":4,"len":1,"data":"01"}]}
+
+# Set cleaning mode to "Floor"
+{"ts":T,"cmd":4,"dp":[{"id":1,"type":4,"len":1,"data":"00"}]}
+
+# Query all status
+{"ts":T,"cmd":9,"dp":[{"id":0},{"id":1},{"id":50},{"id":11}]}
+```
+
+### Device Model UUID Summary
+
+| Model | Service UUID | Write Char | Notify Char |
+|-------|--------------|------------|-------------|
+| K1/S1/S2 | 00001000-... | 1001 | 1002 |
+| DS20 Solar | 000000ee-... | EE01 | EE01 |
+| DS20 Solar | 000000ff-... | FF01 | FF01 |
+
+---
+
+## References
+
+- **APK Source Files**:
+  - `k1/AbstractC0300a.java` - BLE UUIDs
+  - `R1/f.java` - GATT callbacks, connection states
+  - `B2/p.java` - Write operations
+  - `com/ble/ble/BleService.java` - Service architecture
+
+- **Implementation**:
+  - `wybot_ble_client.py` - Home Assistant BLE client
+  - `wybot_mqtt_client.py` - MQTT protocol reference
+  - `wybot_dp_models.py` - DP model definitions
+
+---
+
+## Live Testing Results (January 2026)
+
+### Test Environment
+- **Home Assistant**: 2026.1.2
+- **Bluetooth Proxy**: ESPHome `esp32-bluetooth-proxy-01f424` at 192.168.x.x
+- **Devices Tested**:
+  - DS20 Solar Dock (BLE name: `3C8427565A1A`)
+  - S2 Pro Robot (BLE name: `CCBA97932A96`)
+
+### Verified Findings
+
+#### 1. Device Discovery
+- DS20 Solar Dock advertises as `DS20-3C8427565A1A`
+- Robot BLE name is MAC without colons: `CCBA97932A96`
+- ESPHome Bluetooth proxy successfully discovers devices
+
+#### 2. Service/Characteristic Confirmation
+- **DS20 Solar Dock uses `000000ff` service** with `0000ff01` characteristic
+- Notifications enabled successfully on FF01
+- Write operations work with JSON commands
+
+#### 3. Query Command Format (Working)
+```json
+{"ts":1768707077,"cmd":9,"dp":[]}
+```
+- Empty `dp` array queries all available DPs
+- Response is binary format (not JSON)
+
+#### 4. Captured Response Data
+```
+Response 1: 000102030405060708090a0b0c0d0e (initialization)
+Response 2: aa550005380000040101320002012c... (status with 11 DPs)
+Response 3: aa5500121a00012a0d020107... (device info with paired robot MAC)
+Response 4: aa55001c0100001c (acknowledgment)
+```
+
+#### 5. Decoded Status Data
+| DP | Name | Value | Interpretation |
+|----|------|-------|----------------|
+| 0 | CleaningStatus | 01 | Stopped |
+| 50 | Battery | 012c | 44%, Charging |
+| 131 | SolarEnergy | 33783900 | 3,766,323 Wh total |
+| 209 | DeviceStatus | 03 | Active |
+| 212 | ConnectionStatus | 01 | Connected |
+| 213 | DockConnectionStatus | 01 | Robot docked |
+| 214 | DockInfo | 05 | Solar dock |
+| 221 | SolarDockBattery | 01470a | 71% |
+| 222 | SolarStatus | 01 | Currently charging |
+
+#### 6. Device Pairing Info (cmd=0x12)
+The dock stores information about the paired robot:
+- Robot device ID: `64893b4e841230014a333830`
+- Robot MAC: `CC:BA:97:93:2A:96`
+
+### Key Protocol Differences from MQTT
+
+| Aspect | MQTT | BLE |
+|--------|------|-----|
+| Message format | JSON | Binary |
+| Response format | JSON | Binary (AA55 header) |
+| Query command | JSON with dp list | JSON with empty dp |
+| Characteristic | N/A | FF01 (DS20), 1001 (K1) |
+
+#### 7. Start Cleaning Command Test (Verified)
+
+**Command Sent:**
+```json
+{"ts":1768708070,"cmd":4,"dp":[{"id":0,"type":4,"len":1,"data":"03"}]}
+```
+- `dp_id=0` (CleaningStatus), `data="03"` (CLEANING)
+
+**Response Received:**
+```
+aa550005380000040101320002013383020433783900d10401
+03d40401055d04010100df000201470adc000101de00040000
+5abb1c
+```
+
+**Parsed Response DPs:**
+| DP | Name | Value | Interpretation |
+|----|------|-------|----------------|
+| 0 | CleaningStatus | 01 | **Stopped** (command acknowledged but not executed) |
+| 50 | Battery | 0133 | 51%, Charging |
+| 131 | SolarEnergy | 33783900 | 3,766,323 Wh |
+| 209 | DeviceStatus | 03 | Active |
+| 212 | ConnectionStatus | 01 | Connected |
+| 213 | DockConnectionStatus | **01** | **Docked** |
+| 214 | DockInfo | 05 | Solar dock |
+| 221 | SolarDockBattery | 01470a | 71% |
+| 222 | SolarStatus | 01 | Charging |
+| 223 | Unknown | 00005abb | Unknown data |
+
+**Conclusion:**
+- The BLE write command was **successfully sent and acknowledged**
+- Robot remained in STOPPED state because it's **docked on the solar dock**
+- When robot is docked (DP 213 = 01), start cleaning commands are **ignored**
+
+**VERIFIED WORKING (January 2026 via PacketLogger capture):**
+
+The WyBot app uses **binary AA55 format** sent to **EE01 characteristic**, NOT JSON to FF01!
+
+| What | Wrong (didn't work) | Correct (works!) |
+|------|---------------------|------------------|
+| Format | JSON `{"cmd":4,"dp":[...]}` | Binary `aa5500040400000401030f` |
+| Characteristic | FF01 (`0000ff01-...`) | **EE01** (`0000ee01-...`) |
+| Handle | 0x0029 | **0x002e** |
+
+**Start Cleaning Command (binary):**
+```
+aa5500040400000401030f
+
+Breakdown:
+- aa55     = WyBot header
+- 0004     = cmd 4 (write)
+- 0400     = payload length (4 bytes)
+- 00       = DP ID 0 (CleaningStatus)
+- 04       = type 4 (enum)
+- 01       = value length
+- 03       = value (CLEANING)
+- 0f       = checksum
+```
+
+**Other binary commands:**
+- Stop cleaning: `aa5500040400000401010d` (DP 0 = 01)
+- Return to dock: `aa55000404000b0401011a` (DP 11 = 01)
+
+---
+
+*Document generated from APK analysis and live device testing (January 2026). Protocol details may vary between firmware versions.*

--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+bleak = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.11"
+python_full_version = "3.11.14"

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -1,0 +1,95 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "5876971c347532c7e43cad1ac5925f7c36532b2e9c3aed551e8d5d6504aa2df1"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_full_version": "3.11.14",
+            "python_version": "3.11"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "bleak": {
+            "hashes": [
+                "sha256:4600cc5852f2392ce886547e127623f188e689489c5946d422172adf80635cf9",
+                "sha256:61ac1925073b580c896a92a8c404088c5e5ec9dc3c5bd6fc17554a15779d83de"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==2.1.1"
+        },
+        "pyobjc-core": {
+            "hashes": [
+                "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a",
+                "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc",
+                "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21",
+                "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882",
+                "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962",
+                "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43",
+                "sha256:93418e79c1655f66b4352168f8c85c942707cb1d3ea13a1da3e6f6a143bacda7",
+                "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==12.1"
+        },
+        "pyobjc-framework-cocoa": {
+            "hashes": [
+                "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a",
+                "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858",
+                "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640",
+                "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118",
+                "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc",
+                "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44",
+                "sha256:9b880d3bdcd102809d704b6d8e14e31611443aa892d9f60e8491e457182fdd48",
+                "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==12.1"
+        },
+        "pyobjc-framework-corebluetooth": {
+            "hashes": [
+                "sha256:15ba5207ca626dffe57ccb7c1beaf01f93930159564211cb97d744eaf0d812aa",
+                "sha256:1daf07a0047c3ed89fab84ad5f6769537306733b6a6e92e631581a0f419e3f32",
+                "sha256:37e6456c8a076bd5a2bdd781d0324edd5e7397ef9ac9234a97433b522efb13cf",
+                "sha256:5a894f695e6c672f0260327103a31ad8b98f8d4fb9516a0383db79a82a7e58dc",
+                "sha256:8060c1466d90bbb9100741a1091bb79975d9ba43911c9841599879fc45c2bbe0",
+                "sha256:937849f4d40a33afbcc56cbe90c8d1fbf30fb27a962575b9fb7e8e2c61d3c551",
+                "sha256:e5385195bd365a49ce70e2fb29953681eefbe68a7b15ecc2493981d2fb4a02b1",
+                "sha256:fe72c9732ee6c5c793b9543f08c1f5bdd98cd95dfc9d96efd5708ec9d6eeb213"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==12.1"
+        },
+        "pyobjc-framework-libdispatch": {
+            "hashes": [
+                "sha256:0e9570d7a9a3136f54b0b834683bf3f206acd5df0e421c30f8fd4f8b9b556789",
+                "sha256:0ebfd9e4446ab6528126bff25cfb09e4213ddf992b3208978911cfd3152e45f5",
+                "sha256:23fc9915cba328216b6a736c7a48438a16213f16dfb467f69506300b95938cc7",
+                "sha256:4035535b4fae1b5e976f3e0e38b6e3442ffea1b8aa178d0ca89faa9b8ecdea41",
+                "sha256:50a81a29506f0e35b4dc313f97a9d469f7b668dae3ba597bb67bbab94de446bd",
+                "sha256:58ffce5e6bcd7456b4311009480b195b9f22107b7682fb0835d4908af5a68ad0",
+                "sha256:954cc2d817b71383bd267cc5cd27d83536c5f879539122353ca59f1c945ac706",
+                "sha256:e9f49517e253716e40a0009412151f527005eec0b9a2311ac63ecac1bdf02332"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==12.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
+        }
+    },
+    "develop": {}
+}

--- a/docs/WYBOT_API_MQTT_DOCUMENTATION.md
+++ b/docs/WYBOT_API_MQTT_DOCUMENTATION.md
@@ -1,0 +1,658 @@
+# WYBOT Pool Cleaner API & MQTT Communication Documentation
+
+**Source:** WYBOT Android App v2.1.14 (package: com.wy.winnygo)
+**Extraction Method:** APK decompilation, libapp.so string extraction, and network packet capture analysis
+**Date:** 2025-12-21
+
+This documentation is based ONLY on data extracted from the official WYBOT mobile application and captured network traffic.
+
+---
+
+## Table of Contents
+1. [MQTT Communication](#mqtt-communication)
+2. [HTTP REST API](#http-rest-api)
+3. [Data Point (DP) System](#data-point-dp-system)
+4. [Message Examples from Packet Captures](#message-examples-from-packet-captures)
+
+---
+
+## MQTT Communication
+
+### MQTT Broker Configuration
+
+**Broker Address:** `mqtt.wybotpool.com`
+**Protocol:** MQTT v3.1.1
+**Port:** 1883 (default MQTT)
+
+### Authentication Credentials
+
+**From Packet Capture:**
+```
+Username: wyindustry
+Password: nwe_GTG4faf2qyx8ugx
+```
+
+**Important Note:** These credentials are hardcoded in the application and shared across all users. Device isolation is achieved through topic naming with unique device IDs.
+
+### MQTT Connection Parameters
+
+From captured CONNECT packet:
+- **Protocol:** MQTT v3.1.1 (Version 4)
+- **Clean Session:** Enabled
+- **Keep Alive:** 60 seconds
+- **Client ID Format:** `iWY-<randomString>` (e.g., `iWY-MdTXibGW96`)
+- **Will Topic:** `/will`
+- **Will QoS:** 1 (At least once delivery)
+- **Will Retain:** Enabled
+
+### MQTT Topics
+
+All topics use the device ID as a suffix for device-specific communication.
+
+#### Device Status Topics
+
+**Will Topic (Last Will and Testament):**
+```
+/will/{deviceId}
+```
+Payload when online:
+```json
+{
+	"online":	"1"
+}
+```
+Payload when offline:
+```json
+{
+	"online":	"0"
+}
+```
+
+#### Data Communication Topics
+
+**Query Topic (App → Device):**
+```
+/device/DATA/recv_transparent_query_data/{deviceId}
+```
+Used to request current values of specific data points.
+
+**Command Topic (App → Device):**
+```
+/device/DATA/recv_transparent_cmd_data/{deviceId}
+```
+Used to send control commands to change device state.
+
+**Response Topic (Device → App):**
+```
+/device/DATA/send_transparent_data/{deviceId}
+```
+Device publishes responses and status updates here.
+
+#### OTA/Firmware Update Topics
+
+**OTA Ready Notification:**
+```
+/device/OTA/notify_ready_to_update/{deviceId}
+```
+
+**OTA Update Progress:**
+```
+/device/OTA/post_update_progress/{deviceId}
+```
+
+**OTA Error Codes:**
+```
+/device/OTA/post_errcode/{deviceId}
+```
+
+**OTA Start Update:**
+```
+/device/OTA/recv_start_update/{deviceId}
+```
+
+**OTA Firmware Info Request:**
+```
+/device/OTA/reply_request_all_firmware_info/{deviceId}
+```
+
+**OTA Firmware Info Response:**
+```
+/device/OTA/reply_all_firmware_info/{deviceId}
+```
+
+#### Additional Device-Specific Topics
+
+From string extraction:
+```
+/device/hayward/cus_privacy
+/device/m2/vision_clean_mode_privacy
+```
+
+### Message Structure
+
+All MQTT data messages use JSON format with the following structure:
+
+#### Query Message (cmd = 9)
+```json
+{
+  "cmd": 9,
+  "ts": 1885119988,
+  "dp": [
+    {
+      "id": 1
+    }
+  ]
+}
+```
+
+#### Write Command (cmd = 4)
+```json
+{
+  "cmd": 4,
+  "ts": 1885119988,
+  "dp": [
+    {
+      "id": 0,
+      "type": 4,
+      "len": 1,
+      "data": "01"
+    }
+  ]
+}
+```
+
+#### Response Message (cmd = 5)
+```json
+{
+  "cmd": 5,
+  "ts": 1885119994,
+  "dp": [
+    {
+      "id": 0,
+      "type": 4,
+      "len": 1,
+      "data": "01"
+    },
+    {
+      "id": 50,
+      "type": 0,
+      "len": 2,
+      "data": "0124"
+    }
+  ]
+}
+```
+
+### Command Types
+
+| cmd | Direction | Description |
+|-----|-----------|-------------|
+| 4 | App → Device | Write command (set values) |
+| 5 | Device → App | Response with current values |
+| 9 | App → Device | Query request (read values) |
+
+### Connection Sequence (From Packet Capture)
+
+1. **Connect to MQTT broker** with shared credentials
+2. **Subscribe to topics** (initial subscription):
+   - `/device/OTA/notify_ready_to_update/{deviceId}`
+   - `/will/{deviceId}`
+3. **Receive will message** - Device online status
+4. **Send initial query** - Query DP 1 (cleaning mode)
+5. **Subscribe to data topics**:
+   - `/device/DATA/send_transparent_data/{deviceId}`
+   - `/device/OTA/post_update_progress/{deviceId}`
+6. **Send additional queries** (in rapid succession, <1ms apart):
+   - Query DP 79
+   - Query DP 1
+   - Query DP 0
+   - Query DP 77
+
+---
+
+## HTTP REST API
+
+### Base URL
+```
+https://api.wybotpool.com
+```
+
+### Discovered Endpoints
+
+From libapp.so string extraction:
+
+#### User Management
+- `POST /api/user/login` - User authentication
+- `POST /api/user/register` - New user registration
+- `POST /api/user/reset` - Password reset initiation
+- `POST /api/user/reset/` - Password reset confirmation
+- `GET /api/user` - Get user information
+- `POST /api/user/cancellation` - Account deletion
+- `GET /api/user/notification` - Get notifications
+- `GET /api/user/message` - Get user messages
+
+#### Device Management
+- `GET /api/group/{userId}` - Get all device groups for user
+- `POST /api/device/bind` - Bind new device to account
+- `POST /api/device/release` - Release/unbind device
+- `POST /api/device/ao` - Send command (alternative endpoint)
+
+#### Group Management
+- `GET /api/group` - Get device groups
+- `POST /api/group/remove` - Remove a group
+
+#### Environment/Pool
+- `GET /api/env/pool` - Get pool information
+- `POST /api/env/pool` - Create/update pool
+
+#### Firmware
+- `GET /api/firmware/release` - Get firmware release info
+
+#### Vision/Camera
+- `POST /api/vision` - Vision camera operations
+
+#### Customer Support
+- `POST /api/cs/feedback` - Submit user feedback
+- `POST /api/cs/uploadvideo` - Upload support video
+
+### Data Models
+
+From package references in libapp.so:
+
+**User Models:**
+- `UserInfoModel`
+- `UserInfoEditModel`
+- `UserRestPasswordModel`
+- `UserDeviceBindModel`
+- `UserGroupBindModel`
+- `UserGroupItemModel`
+- `UserNotificationDataModel`
+- `UserMessageOptModel`
+- `UserFeedbackModel`
+
+**Device Models:**
+- `DeviceInfoEditModel`
+- `DeviceListModel`
+- `DeviceReleaseInfoModel`
+- `DeviceOnlineStateModel`
+
+**MQTT Models:**
+- `SendPublishDataModel`
+- `ReceiveSubscribeDataModel`
+- `OtaNoticeDataModel`
+- `OtaUpgradeProgressDataModel`
+- `OtaUpgradeErrorCodeDataModel`
+- `OtaUpgradVersionDataModel`
+
+**Other Models:**
+- `PoolEnvModel`
+- `PoolAddModel`
+- `PoolDeleteModel`
+- `WeatherDataModel`
+- `UploadImageModel`
+- `DeleteDeviceModel`
+- `DeleteAccountModel`
+
+---
+
+## Data Point (DP) System
+
+The WYBOT system uses Data Points (DP) to represent device attributes and controls.
+
+### DP Structure
+
+Each DP consists of:
+- **id**: Integer identifier (0-255)
+- **type**: Data type (0-5)
+- **len**: Length of data in bytes
+- **data**: Hex-encoded value
+
+### Known Data Points
+
+| DP ID | Name/Purpose | Type | Observed Values | Description |
+|-------|--------------|------|-----------------|-------------|
+| 0 | Running/Cleaning Status | 4 | `01`, `03` | Device operational state |
+| 1 | Cleaning Mode | 4 | `00`-`06` | Selected cleaning program |
+| 13 | Unknown | 5 | `80840000` | Purpose unknown |
+| 50 (0x32) | Battery Status | 0 | `0124`, `0164` | Battery state + level |
+| 77 (0x4D) | Unknown Schedule/Config | 0 | 36 bytes | Possibly schedule data |
+| 79 (0x4F) | Unknown Device Info | 2 | 12 bytes | Possibly firmware/device info |
+| 131 (0x83) | Working Time | 2 | 4 bytes | Total working time |
+| 209 (0xD1) | Sonar State | 4 | `03` | Sonar sensor status |
+| 213 (0xD5) | Docker State | 4 | `01` | Docking station state |
+| 214 (0xD6) | Delay Value | 4 | `00` | Timer delay setting |
+
+### Additional DP IDs from String Extraction
+
+From BLE debug messages (may not all be MQTT):
+- **0xCE (206)**: Cleaning depth range
+- **0xCF (207)**: Auto run mode
+- **0xD1 (209)**: Sonar state
+- **0xD4 (212)**: In water state
+- **0xD5 (213)**: Docker state
+- **0xD6 (214)**: Delay value
+- **0xDD (221)**: Charging state
+- **0xDE (222)**: Low power mode
+- **0x91 (145)**: Heavy dirt mode
+- **0x46 (70)**: System time
+
+### DP Data Types
+
+| Type | Format | Description |
+|------|--------|-------------|
+| 0 | Raw | Raw bytes, hex-encoded |
+| 2 | Raw | Raw bytes (multi-byte values) |
+| 4 | Integer | Simple integer value, hex-encoded |
+| 5 | String | String value, hex-encoded |
+
+### Battery Status (DP 50)
+
+DP 50 encodes two values in 4 hex characters (2 bytes):
+
+**Format:** `XXYY`
+- **XX**: Charging state
+  - `00` = Not charging
+  - `01` = Charging
+  - `02` = Fully charged
+- **YY**: Battery percentage (hex 00-64 = 0-100%)
+
+**Examples:**
+- `0124` = Charging, 36% battery (0x24 = 36 decimal)
+- `0164` = Charging, 100% battery (0x64 = 100 decimal)
+- `0250` = Fully charged, 80% battery (0x50 = 80 decimal)
+
+### Cleaning Status (DP 0)
+
+From packet captures:
+- `01` = Cleaning/Running
+- `03` = Stopped (or another mode)
+
+**Note:** The actual status codes need further verification. The mapping may vary by device model.
+
+### Cleaning Mode (DP 1)
+
+From string extraction, available modes:
+- Floor cleaning
+- Wall cleaning
+- Wall then Floor
+- Standard Full-Pool
+- Water Line
+- Strong Floor
+- Eco Floor
+
+Observed value in captures: `03` (likely Standard Full-Pool mode)
+
+---
+
+## Message Examples from Packet Captures
+
+### Example 1: Initial Connection and Query Sequence
+
+**Time:** 2025-12-21 15:06:38
+
+**Step 1: Subscribe to initial topics**
+```
+SUBSCRIBE: /device/OTA/notify_ready_to_update/535032302d2d34b7dae70b66
+SUBSCRIBE: /will/535032302d2d34b7dae70b66
+```
+
+**Step 2: Device publishes online status**
+```
+TOPIC: /will/535032302d2d34b7dae70b66
+PAYLOAD: {"online": "1"}
+```
+
+**Step 3: App sends initial query (DP 1 - cleaning mode)**
+```
+TOPIC: /device/DATA/recv_transparent_query_data/535032302d2d34b7dae70b66
+PAYLOAD:
+{
+  "ts": 1885215978,
+  "dp": [{"id": 1}],
+  "cmd": 9
+}
+```
+
+**Step 4: Subscribe to data topics**
+```
+SUBSCRIBE: /device/DATA/send_transparent_data/535032302d2d34b7dae70b66
+SUBSCRIBE: /device/OTA/post_update_progress/535032302d2d34b7dae70b66
+```
+
+**Step 5: App sends rapid queries (<1ms apart)**
+
+Query DP 79:
+```json
+{
+  "cmd": 9,
+  "dp": [{"id": 79}],
+  "ts": 1885215979
+}
+```
+
+Query DP 1:
+```json
+{
+  "cmd": 9,
+  "dp": [{"id": 1}],
+  "ts": 1885215980
+}
+```
+
+Query DP 0:
+```json
+{
+  "cmd": 9,
+  "dp": [{"id": 0}],
+  "ts": 1885215981
+}
+```
+
+Query DP 77:
+```json
+{
+  "cmd": 9,
+  "dp": [{"id": 77}],
+  "ts": 1885215984
+}
+```
+
+### Example 2: Device Response with Multiple Data Points
+
+```
+TOPIC: /device/DATA/send_transparent_data/535032302d2d34b7dae70b66
+PAYLOAD:
+{
+  "cmd": 5,
+  "ts": 1885119994,
+  "dp": [
+    {
+      "id": 0,
+      "type": 4,
+      "len": 1,
+      "data": "01"
+    },
+    {
+      "id": 50,
+      "type": 0,
+      "len": 2,
+      "data": "0124"
+    },
+    {
+      "id": 131,
+      "type": 2,
+      "len": 4,
+      "data": "4a000000"
+    },
+    {
+      "id": 209,
+      "type": 4,
+      "len": 1,
+      "data": "03"
+    },
+    {
+      "id": 213,
+      "type": 4,
+      "len": 1,
+      "data": "01"
+    },
+    {
+      "id": 214,
+      "type": 4,
+      "len": 1,
+      "data": "00"
+    },
+    {
+      "id": 13,
+      "type": 5,
+      "len": 4,
+      "data": "80840000"
+    }
+  ]
+}
+```
+
+**Interpretation:**
+- DP 0 = `01` → Device is cleaning
+- DP 50 = `0124` → Charging, 36% battery
+- DP 131 = `4a000000` → Working time (74 units, possibly minutes)
+- DP 209 = `03` → Sonar state
+- DP 213 = `01` → Docker state (connected/docked)
+- DP 214 = `00` → No delay set
+- DP 13 = `80840000` → Unknown system value
+
+### Example 3: Cleaning Mode Response
+
+```
+TOPIC: /device/DATA/send_transparent_data/535032302d2d34b7dae70b66
+PAYLOAD:
+{
+  "cmd": 5,
+  "ts": 1885215979,
+  "dp": [
+    {
+      "id": 1,
+      "type": 4,
+      "len": 1,
+      "data": "03"
+    }
+  ]
+}
+```
+
+**Interpretation:**
+- DP 1 = `03` → Cleaning mode #3 (likely "Standard Full-Pool")
+
+### Example 4: DP 77 Extended Data
+
+```json
+{
+  "cmd": 5,
+  "ts": 1885215984,
+  "dp": [
+    {
+      "id": 77,
+      "type": 0,
+      "len": 36,
+      "data": "7f0900000003090000000309000000030900000003090000000309000000030"
+    }
+  ]
+}
+```
+
+**Interpretation:**
+DP 77 contains 36 bytes of data. Pattern suggests it might be a schedule or configuration with repeated blocks (`09000000 03` appears 7 times).
+
+### Example 5: DP 79 Device Info
+
+```json
+{
+  "cmd": 5,
+  "ts": 1885215979,
+  "dp": [
+    {
+      "id": 79,
+      "type": 2,
+      "len": 12,
+      "data": "01072f010707020201070700"
+    }
+  ]
+}
+```
+
+**Interpretation:**
+12 bytes that might encode firmware version, hardware revision, or device capabilities.
+
+---
+
+## Device Models
+
+From string extraction, the following device types are referenced in the app:
+
+### Cleaner Models
+- S1
+- S2 (including Solar variants)
+- S3
+- WY200BW
+- WY3052
+- HJ4042
+- 3092
+- 3312
+- 350sp
+- SP20
+- M2
+- OS600
+- A1
+- C2
+
+### Docking Station Models
+- DS20
+
+---
+
+## Additional Information
+
+### Weather Integration
+The app integrates with OpenWeatherMap:
+```
+https://api.openweathermap.org/data/2.5/weather
+```
+
+### Support Resources
+- Website: `https://wybotpool.com`
+- EU Website: `https://www.eu.wybotpool.com`
+- Email: `support@wybotpool.com`
+
+### User Agent
+When making HTTP API calls, the app uses:
+```
+User-Agent: WYBOT/13 CFNetwork/1498.700.2 Darwin/23.6.0
+```
+(Note: This was found in the Python code, not verified in packet captures)
+
+---
+
+## Implementation Notes
+
+1. **Query Timing:** The app sends DP queries in very rapid succession (<1ms between queries), not with delays.
+
+2. **Subscription Pattern:** The app subscribes to will/OTA topics first, waits for device online status, then queries and subscribes to data topics.
+
+3. **Client ID:** Each app instance generates a random client ID with the prefix `iWY-`.
+
+4. **Will Message:** The MQTT connection includes a Last Will and Testament on the `/will` topic to detect app disconnection.
+
+5. **Device IDs:** Device IDs appear to be 24-character hex strings (e.g., `535032302d2d34b7dae70b66`).
+
+6. **Data Encoding:** All DP data values are hex-encoded strings, regardless of the data type.
+
+7. **Timestamps:** Unix epoch timestamps in milliseconds (integer, not float).
+
+---
+
+**Document Version:** 2.0
+**Last Updated:** 2025-12-21
+**Data Sources:**
+- WYBOT Android App (com.wy.winnygo) v2.1.14
+- libapp_arm64.so string extraction
+- Network packet captures (app open.pcapng, appopen_online.pcapng, appopen_cleaning.pcapng)

--- a/docs/WYBOT_PROTOCOL_SPECIFICATION.md
+++ b/docs/WYBOT_PROTOCOL_SPECIFICATION.md
@@ -1,0 +1,609 @@
+# WYBOT Protocol Complete Specification
+
+**Source:** WYBOT Android App v2.1.14 (com.wy.winnygo) - Extracted from Flutter App ONLY
+**Date:** 2025-12-21
+**Methods:** APK decompilation, libapp_arm64.so string extraction, MQTT packet capture analysis
+
+---
+
+## Command Types
+
+Based on packet capture analysis, there are exactly **3 command types**:
+
+| cmd | Name | Direction | Purpose | Observed Count |
+|-----|------|-----------|---------|----------------|
+| 4 | WRITE | App → Device | Send control commands to change device state | 0 (not in captures, inferred) |
+| 5 | RESPONSE | Device → App | Device sends current values or acknowledges commands | 19 |
+| 9 | QUERY | App → Device | Request current values of specific DPs | 5 |
+
+### Command Structure
+
+All commands use identical JSON structure:
+
+```json
+{
+  "cmd": <number>,
+  "ts": <unix_timestamp_ms>,
+  "dp": [<dp_array>]
+}
+```
+
+**Fields:**
+- `cmd`: Command type (4, 5, or 9)
+- `ts`: Unix timestamp in milliseconds (integer)
+- `dp`: Array of Data Point objects
+
+### DP Object Structure
+
+#### Query (cmd=9) - Minimal Structure
+```json
+{
+  "id": <dp_id>
+}
+```
+
+#### Write (cmd=4) & Response (cmd=5) - Full Structure
+```json
+{
+  "id": <dp_id>,
+  "type": <data_type>,
+  "len": <data_length>,
+  "data": "<hex_string>"
+}
+```
+
+---
+
+## Data Types
+
+Based on observed packets and libapp.so model references:
+
+| Type | Name | Encoding | Description | Example |
+|------|------|----------|-------------|---------|
+| 0 | RAW | Hex string | Raw bytes, no special interpretation | `"0124"` |
+| 2 | RAW_MULTI | Hex string | Multi-byte raw values | `"4a000000"` |
+| 4 | INTEGER | Hex string | Simple integer, convert hex to decimal | `"03"` |
+| 5 | STRING | Hex string | String data, hex-encoded | `"80840000"` |
+
+**Important:** All data values are hex-encoded strings, even for type 4 (integers).
+
+---
+
+## Complete Data Point (DP) Map
+
+### DPs from Packet Captures (MQTT - Verified)
+
+| DP ID | Hex | Type | Len | Name | Decoding | Example |
+|-------|-----|------|-----|------|----------|---------|
+| 0 | 0x00 | 4 | 1 | Running/Cleaning Status | `"01"` = 1 (cleaning)<br/>`"03"` = 3 (stopped) | `"01"` |
+| 1 | 0x01 | 4 | 1 | Cleaning Mode | `"00"`-`"06"` = mode 0-6 | `"03"` |
+| 13 | 0x0D | 5 | 4 | System Value | Unknown purpose | `"80840000"` |
+| 50 | 0x32 | 0 | 2 | Battery Status | Byte 1: charge state<br/>Byte 2: percentage (0-100) | `"0124"` |
+| 77 | 0x4D | 0 | 36 | Schedule/Config | 36 bytes, repeating pattern | `"7f09..."` |
+| 79 | 0x4F | 2 | 12 | Device Info | 12 bytes, firmware/hardware info | `"01072f..."` |
+| 131 | 0x83 | 2 | 4 | Working Time | 32-bit little-endian integer (minutes) | `"4a000000"` |
+| 209 | 0xD1 | 4 | 1 | Sonar State | State value | `"03"` |
+| 213 | 0xD5 | 4 | 1 | Docker/Dock State | Docking station state | `"01"` |
+| 214 | 0xD6 | 4 | 1 | Delay Value | Timer delay | `"00"` |
+
+### Additional DPs from Debug Strings (BLE/Unverified)
+
+These are referenced in the app but not confirmed in MQTT captures:
+
+| DP ID | Hex | Source | Description |
+|-------|-----|--------|-------------|
+| 70 | 0x46 | parseBLEData | System Time |
+| 72 | 0x48 | parseDataById | Unknown pool parameter |
+| 73 | 0x49 | parseDataById | Unknown pool parameter |
+| 74 | 0x4A | parseDataById | Unknown pool parameter |
+| 75 | 0x4B | parseDataById | Unknown pool parameter |
+| 142 | 0x8E | parseBLEData | pH Data + Temperature Data |
+| 145 | 0x91 | Debug string | Heavy Dirt Mode |
+| 206 | 0xCE | parseBLEData | Cleaning Depth Range |
+| 207 | 0xCF | parseBLEData | Auto Run Mode |
+| 212 | 0xD4 | Debug string | In Water State |
+| 221 | 0xDD | Debug string | Charging State (MQTT delay check) |
+| 222 | 0xDE | Debug string | Low Power Value (MQTT delay check) |
+| ? | ? | parseBLEData | Vision Mode Enable |
+| ? | ? | parseBLEData | Manual Control Auto Return Back |
+
+---
+
+## DP Decoding Details
+
+### DP 0 - Running/Cleaning Status (Type 4, Len 1)
+
+**Encoding:** Single byte hex
+
+**Values:**
+- `"01"` = 0x01 = 1 decimal → **Cleaning/Running**
+- `"03"` = 0x03 = 3 decimal → **Stopped**
+
+**Usage:** Indicates whether device is actively cleaning
+
+---
+
+### DP 1 - Cleaning Mode (Type 4, Len 1)
+
+**Encoding:** Single byte hex
+
+**Known Modes (from string extraction):**
+- `"00"` = 0 → Floor
+- `"01"` = 1 → Wall
+- `"02"` = 2 → Wall then Floor
+- `"03"` = 3 → Standard Full-Pool
+- `"04"` = 4 → Water Line
+- `"05"` = 5 → Strong Floor
+- `"06"` = 6 → Eco Floor
+
+**Observed Value:** `"03"` (Standard Full-Pool)
+
+---
+
+### DP 13 - System Value (Type 5, Len 4)
+
+**Encoding:** 4-byte hex string
+
+**Observed Value:** `"80840000"` = [0x80, 0x84, 0x00, 0x00]
+
+**Purpose:** Unknown. Possibly system flags or configuration.
+
+---
+
+### DP 50 - Battery Status (Type 0, Len 2)
+
+**Encoding:** 2-byte hex string `XXYY`
+
+**Byte 1 (XX) - Charging State:**
+- `00` = Not charging
+- `01` = Charging
+- `02` = Fully charged
+
+**Byte 2 (YY) - Battery Percentage:**
+- Hex value 00-64 = 0-100 decimal percentage
+
+**Examples:**
+- `"0124"` → Charging, 36% (0x24 = 36 decimal)
+- `"0164"` → Charging, 100% (0x64 = 100 decimal)
+- `"0250"` → Fully charged, 80% (0x50 = 80 decimal)
+
+---
+
+### DP 77 - Schedule/Config (Type 0, Len 36)
+
+**Encoding:** 36-byte hex string
+
+**Observed Pattern:**
+```
+7f 09 00 00 00 03
+09 00 00 00 03 09
+00 00 00 03 09 00
+00 00 03 09 00 00
+00 03 09 00 00 00
+03 09 00 00 00 03
+```
+
+**Analysis:** Repeating pattern `09 00 00 00 03` appears 7 times (for 7 days?). Likely weekly schedule configuration.
+
+---
+
+### DP 79 - Device Info (Type 2, Len 12)
+
+**Encoding:** 12-byte hex string
+
+**Observed Value:** `"01072f010707020201070700"`
+
+**Bytes:** `[01, 07, 2f, 01, 07, 07, 02, 02, 01, 07, 07, 00]`
+**Decimal:** `[1, 7, 47, 1, 7, 7, 2, 2, 1, 7, 7, 0]`
+
+**Hypothesis:** Firmware version, hardware revision, or device capabilities encoding.
+
+---
+
+### DP 131 - Working Time (Type 2, Len 4)
+
+**Encoding:** 32-bit little-endian integer (minutes)
+
+**Observed Value:** `"4a000000"`
+
+**Decoding:**
+```
+Hex: 4a 00 00 00
+Little-endian 32-bit: 0x0000004a = 74 decimal
+= 74 minutes = 1 hour 14 minutes
+```
+
+**Purpose:** Total working time counter
+
+---
+
+### DP 209 - Sonar State (Type 4, Len 1)
+
+**Encoding:** Single byte hex
+
+**Observed Value:** `"03"` = 3 decimal
+
+**Purpose:** Sonar sensor state/status
+
+---
+
+### DP 213 - Docker/Dock State (Type 4, Len 1)
+
+**Encoding:** Single byte hex
+
+**Observed Value:** `"01"` = 1 decimal
+
+**Purpose:** Docking station connection/state
+- `01` = Connected/Docked (inferred)
+
+---
+
+### DP 214 - Delay Value (Type 4, Len 1)
+
+**Encoding:** Single byte hex
+
+**Observed Value:** `"00"` = 0 decimal
+
+**Purpose:** Timer delay setting (no delay set)
+
+---
+
+## Message Sequence Patterns
+
+### Initial Connection Sequence
+
+From packet captures at 2025-12-21 15:06:38:
+
+**1. Subscribe Phase (0ms)**
+```
+SUBSCRIBE: /will/{deviceId}
+SUBSCRIBE: /device/OTA/notify_ready_to_update/{deviceId}
+```
+
+**2. Device Online (0.2ms later)**
+```
+PUBLISH: /will/{deviceId}
+{"online": "1"}
+```
+
+**3. Initial Query (~6 seconds later)**
+```
+PUBLISH: /device/DATA/recv_transparent_query_data/{deviceId}
+{
+  "cmd": 9,
+  "ts": 1885215978,
+  "dp": [{"id": 1}]
+}
+```
+
+**4. Subscribe to Data Topics (1.3ms later)**
+```
+SUBSCRIBE: /device/DATA/send_transparent_data/{deviceId}
+SUBSCRIBE: /device/OTA/post_update_progress/{deviceId}
+```
+
+**5. Rapid Query Burst (<1ms between each)**
+```
+QUERY DP 79  (ts: 1885215979)
+QUERY DP 1   (ts: 1885215980)
+QUERY DP 0   (ts: 1885215981)
+QUERY DP 77  (ts: 1885215984)
+```
+
+**Query Timing Analysis:**
+- DP 1 to DP 79: 1ms
+- DP 79 to DP 1 (2nd): 1ms
+- DP 1 to DP 0: 1ms
+- DP 0 to DP 77: 3ms
+
+---
+
+## Response Patterns
+
+### Single DP Response
+
+When querying a single DP, device responds with just that DP:
+
+**Query:**
+```json
+{
+  "cmd": 9,
+  "dp": [{"id": 1}],
+  "ts": 1885119988
+}
+```
+
+**Response:**
+```json
+{
+  "cmd": 5,
+  "ts": 1885119989,
+  "dp": [
+    {
+      "id": 1,
+      "type": 4,
+      "len": 1,
+      "data": "03"
+    }
+  ]
+}
+```
+
+### Batch Response
+
+Device can respond with multiple DPs in one message:
+
+```json
+{
+  "cmd": 5,
+  "ts": 1885119994,
+  "dp": [
+    {"id": 0, "type": 4, "len": 1, "data": "01"},
+    {"id": 50, "type": 0, "len": 2, "data": "0124"},
+    {"id": 131, "type": 2, "len": 4, "data": "4a000000"},
+    {"id": 209, "type": 4, "len": 1, "data": "03"},
+    {"id": 213, "type": 4, "len": 1, "data": "01"},
+    {"id": 214, "type": 4, "len": 1, "data": "00"},
+    {"id": 13, "type": 5, "len": 4, "data": "80840000"}
+  ]
+}
+```
+
+### Duplicate Responses
+
+Device may send the same DP multiple times (observed: DP 1 sent 5+ times consecutively).
+
+---
+
+## Write Commands (cmd=4)
+
+**Not observed in packet captures**, but structure can be inferred:
+
+```json
+{
+  "cmd": 4,
+  "ts": <timestamp>,
+  "dp": [
+    {
+      "id": <dp_id>,
+      "type": <type>,
+      "len": <length>,
+      "data": "<hex_value>"
+    }
+  ]
+}
+```
+
+**Example - Start Cleaning:**
+```json
+{
+  "cmd": 4,
+  "ts": 1885120000,
+  "dp": [
+    {
+      "id": 0,
+      "type": 4,
+      "len": 1,
+      "data": "01"
+    }
+  ]
+}
+```
+
+**Example - Change to Floor Mode:**
+```json
+{
+  "cmd": 4,
+  "ts": 1885120000,
+  "dp": [
+    {
+      "id": 1,
+      "type": 4,
+      "len": 1,
+      "data": "00"
+    }
+  ]
+}
+```
+
+---
+
+## BLE vs MQTT Data Points
+
+The app uses **both** BLE (Bluetooth Low Energy) and MQTT for communication:
+
+### MQTT Data Points (Cloud/Remote)
+DPs observed in MQTT packet captures:
+- 0, 1, 13, 50, 77, 79, 131, 209, 213, 214
+
+### BLE Data Points (Local/Bluetooth)
+DPs referenced only in BLE parsing code:
+- 70 (0x46) - System Time
+- 72-75 (0x48-0x4B) - Pool parameters
+- 142 (0x8E) - pH & Temperature
+- 145 (0x91) - Heavy Dirt Mode
+- 206 (0xCE) - Cleaning Depth
+- 207 (0xCF) - Auto Run Mode
+- 212 (0xD4) - In Water State
+- Vision Mode Enable
+- Manual Control Auto Return
+
+**Note:** BLE DPs may have different encoding or may not be available via MQTT.
+
+---
+
+## Data Models from Flutter App
+
+### MQTT Message Models
+
+From `package:WYBOT/mqt/` references:
+
+**SendPublishDataModel** (App → Device)
+- Fields: `_cmd`, `_ts`, `_dp`
+- Used for cmd=4 (write) and cmd=9 (query)
+
+**ReceiveSubscribeDataModel** (Device → App)
+- Fields: `_cmd`, `_ts`, `_dp`
+- Used for cmd=5 (response)
+
+**DP Model**
+- Fields: `_id`, `_type`, `_len`, `_data`
+
+### OTA Models
+
+- `OtaNoticeDataModel`
+- `OtaUpgradeProgressDataModel`
+- `OtaUpgradeErrorCodeDataModel`
+- `OtaUpgradVersionDataModel`
+
+### Device Models
+
+- `DeviceOnlineStateModel` - Contains `_online` field
+- `DeviceInfoEditModel` - Contains `_code` field
+- `DeviceListModel`
+- `DeviceReleaseInfoModel`
+
+---
+
+## Encoding Rules Summary
+
+### Hex String Encoding
+
+**All DP data is hex-encoded strings:**
+
+1. **Type 4 (Integer):** Single byte or multi-byte hex
+   - `"01"` = 1 decimal
+   - `"03"` = 3 decimal
+   - `"64"` = 100 decimal
+
+2. **Type 0 (Raw Bytes):** Direct hex representation
+   - `"0124"` = two bytes [0x01, 0x24]
+   - Read byte-by-byte for interpretation
+
+3. **Type 2 (Multi-byte Raw):** Usually integers with specific byte order
+   - `"4a000000"` = little-endian 32-bit = 74 decimal
+
+4. **Type 5 (String):** Hex-encoded string data
+   - May need additional decoding based on context
+
+### Timestamp Encoding
+
+- Unix epoch time in **milliseconds**
+- Integer format (not float)
+- Example: `1885119988` = 1885119988 ms since epoch
+
+### Device ID Encoding
+
+- 24-character hex string
+- Example: `535032302d2d34b7dae70b66`
+
+---
+
+## Implementation Notes
+
+### Query Strategy
+
+The app queries DPs individually, not in batch:
+```
+Query DP 1
+Query DP 79
+Query DP 1  (again!)
+Query DP 0
+Query DP 77
+```
+
+**Important:** Query timing is <1ms between queries, essentially simultaneous.
+
+### Response Handling
+
+- Device may respond to each query individually
+- Device may batch multiple responses
+- Device may send duplicate responses
+- App must handle all patterns
+
+### Data Type Selection
+
+When writing (cmd=4), match the type to what the device uses in responses (cmd=5):
+- If device sends type 4, use type 4
+- If device sends type 0, use type 0
+- Type and len must match device's format
+
+### Error Handling
+
+No error codes observed in packet captures. Failure modes unknown.
+
+---
+
+## Complete Example: Device Status Update Flow
+
+**Scenario:** Device cleaning, 36% battery
+
+```json
+{
+  "cmd": 5,
+  "ts": 1885119994,
+  "dp": [
+    {
+      "id": 0,
+      "type": 4,
+      "len": 1,
+      "data": "01"
+    },
+    {
+      "id": 50,
+      "type": 0,
+      "len": 2,
+      "data": "0124"
+    },
+    {
+      "id": 131,
+      "type": 2,
+      "len": 4,
+      "data": "4a000000"
+    },
+    {
+      "id": 209,
+      "type": 4,
+      "len": 1,
+      "data": "03"
+    },
+    {
+      "id": 213,
+      "type": 4,
+      "len": 1,
+      "data": "01"
+    },
+    {
+      "id": 214,
+      "type": 4,
+      "len": 1,
+      "data": "00"
+    },
+    {
+      "id": 13,
+      "type": 5,
+      "len": 4,
+      "data": "80840000"
+    }
+  ]
+}
+```
+
+**Decoded:**
+- DP 0 = `01` → **Cleaning**
+- DP 50 = `0124` → **Charging, 36% battery**
+- DP 131 = `4a000000` → **74 minutes working time**
+- DP 209 = `03` → **Sonar state 3**
+- DP 213 = `01` → **Docked**
+- DP 214 = `00` → **No delay**
+- DP 13 = `80840000` → **Unknown system value**
+
+---
+
+**Document Version:** 1.0
+**Last Updated:** 2025-12-21
+**Data Sources:**
+- WYBOT Android App (com.wy.winnygo) v2.1.14
+- libapp_arm64.so string extraction
+- MQTT packet captures (appopen.pcapng, appopen_online.pcapng, appopen_cleaning.pcapng)
+- No Python code referenced - Flutter app data only

--- a/docs/ble_test_script.py
+++ b/docs/ble_test_script.py
@@ -1,0 +1,1338 @@
+#!/usr/bin/env python3
+"""BLE test script for WyBot devices.
+
+This script can be run standalone to test BLE communication with WyBot devices.
+It discovers services, captures notifications, and tests commands.
+
+Usage:
+    python ble_test_script.py scan                    # Scan for WyBot devices
+    python ble_test_script.py discover <MAC>          # Discover services
+    python ble_test_script.py wake <MAC>              # Wake device via BLE
+    python ble_test_script.py query <MAC>             # Query device status
+    python ble_test_script.py monitor <MAC> [seconds] # Monitor notifications
+    python ble_test_script.py start <MAC>             # Start cleaning (JSON format - may not work when docked)
+    python ble_test_script.py start <MAC> --mode 1    # Start cleaning with mode (0=Floor, 1=Wall, etc)
+    python ble_test_script.py stop <MAC>              # Stop cleaning (JSON format)
+    python ble_test_script.py undock <MAC>            # Undock/return from dock
+    python ble_test_script.py full-clean <MAC>        # Full sequence: undock, wait, start cleaning
+    python ble_test_script.py start-binary <MAC>      # Start cleaning (binary format to EE01 - WORKS!)
+    python ble_test_script.py stop-binary <MAC>       # Stop cleaning (binary format to EE01)
+    python ble_test_script.py return-binary <MAC>     # Return to dock (binary format to EE01)
+    python ble_test_script.py set-mode <MAC> <0-6>    # Set cleaning mode (0=Floor...6=Eco)
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import time
+
+try:
+    from bleak import BleakClient, BleakScanner
+    from bleak.backends.device import BLEDevice
+except ImportError:
+    print("Error: bleak library not installed. Run: pip install bleak")
+    sys.exit(1)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+_LOGGER = logging.getLogger(__name__)
+
+# =============================================================================
+# BLE UUIDs (from protocol documentation)
+# =============================================================================
+
+# DS20 Solar Dock
+SERVICE_UUID_EE = "000000ee-0000-1000-8000-00805f9b34fb"
+SERVICE_UUID_FF = "000000ff-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_EE01 = "0000ee01-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_FF01 = "0000ff01-0000-1000-8000-00805f9b34fb"
+
+# K1/S1/S2 Series
+SERVICE_UUID_K1 = "00001000-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_1001 = "00001001-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_1002 = "00001002-0000-1000-8000-00805f9b34fb"
+
+KNOWN_SERVICE_UUIDS = [
+    SERVICE_UUID_EE.lower(),
+    SERVICE_UUID_FF.lower(),
+    SERVICE_UUID_K1.lower(),
+]
+
+# Connection settings
+CONNECTION_TIMEOUT = 15.0
+WAKE_HOLD_TIME = 5.0
+
+
+def build_binary_command(cmd: int, dp_id: int, dp_type: int, dp_len: int, dp_value: bytes) -> bytes:
+    """Build a binary AA55 format command for BLE.
+
+    The WyBot app uses binary format, not JSON, for BLE commands.
+    Format: AA55 + cmd(2) + len(2) + DP data + checksum
+
+    Args:
+        cmd: Command type (4 = write, 9 = query)
+        dp_id: Data Point ID
+        dp_type: Data Point type (4 = enum)
+        dp_len: Length of dp_value
+        dp_value: The value bytes
+
+    Returns:
+        Complete binary command with header and checksum
+    """
+    # Build DP data: id + type + len + value
+    dp_data = bytes([dp_id, dp_type, dp_len]) + dp_value
+
+    # Build packet: header + cmd + payload_len + dp_data
+    header = b'\xaa\x55'
+    cmd_bytes = cmd.to_bytes(2, 'big')
+    payload_len = len(dp_data).to_bytes(2, 'big')
+
+    packet = header + cmd_bytes + payload_len + dp_data
+
+    # Calculate checksum (sum of all bytes after header, mod 256)
+    checksum = sum(packet[2:]) & 0xFF
+
+    return packet + bytes([checksum])
+
+
+# Pre-built binary commands (captured from WyBot app via PacketLogger)
+# IMPORTANT: Must be sent to EE01 characteristic, NOT FF01!
+BINARY_CMD_START_CLEANING = bytes.fromhex('aa5500040400000401030f')  # DP 0 = 03 → Status: Cleaning
+BINARY_CMD_STOP_CLEANING = bytes.fromhex('aa5500040400000401010d')   # DP 0 = 01 → Status: Stopped
+BINARY_CMD_RETURN_TO_DOCK = bytes.fromhex('aa55000404000b04010118')  # DP 11 = 01 → Status: 04 (Returning)
+
+# Cleaning mode commands (DP 1) - captured from WyBot app
+BINARY_CMD_MODE_FLOOR = bytes.fromhex('aa5500040400010401000d')           # Mode 0: Floor
+BINARY_CMD_MODE_WALL = bytes.fromhex('aa5500040400010401010e')            # Mode 1: Wall
+BINARY_CMD_MODE_WALL_THEN_FLOOR = bytes.fromhex('aa5500040400010401020f') # Mode 2: Wall Then Floor
+BINARY_CMD_MODE_ADVANCED = bytes.fromhex('aa55000404000104010310')        # Mode 3: Advanced Full Pool
+BINARY_CMD_MODE_WATERLINE = bytes.fromhex('aa55000404000104010411')       # Mode 4: Water Line
+BINARY_CMD_MODE_TURBO = bytes.fromhex('aa55000404000104010512')           # Mode 5: Turbo Floor
+BINARY_CMD_MODE_ECO = bytes.fromhex('aa55000404000104010613')             # Mode 6: Eco Floor
+
+BINARY_MODE_COMMANDS = {
+    0: BINARY_CMD_MODE_FLOOR,
+    1: BINARY_CMD_MODE_WALL,
+    2: BINARY_CMD_MODE_WALL_THEN_FLOOR,
+    3: BINARY_CMD_MODE_ADVANCED,
+    4: BINARY_CMD_MODE_WATERLINE,
+    5: BINARY_CMD_MODE_TURBO,
+    6: BINARY_CMD_MODE_ECO,
+}
+
+MODE_NAMES = {
+    0: "Floor",
+    1: "Wall",
+    2: "Wall Then Floor",
+    3: "Advanced Full Pool",
+    4: "Water Line",
+    5: "Turbo Floor",
+    6: "Eco Floor",
+}
+
+# The correct characteristic for WRITE commands on DS20 Solar Dock
+# - EE01 (0000ee01-...) = Write commands (handle 0x002e)
+# - FF01 (0000ff01-...) = Notifications/status updates
+CHAR_UUID_EE01_WRITE = "0000ee01-0000-1000-8000-00805f9b34fb"
+CHAR_UUID_FF01_NOTIFY = "0000ff01-0000-1000-8000-00805f9b34fb"
+
+
+def ble_name_to_mac(ble_name: str) -> str:
+    """Convert BLE name (CCBA97932A96) to MAC (CC:BA:97:93:2A:96)."""
+    if len(ble_name) == 12 and all(c in "0123456789ABCDEFabcdef" for c in ble_name):
+        return ":".join(ble_name[i : i + 2] for i in range(0, 12, 2)).upper()
+    return ble_name
+
+
+def is_wybot_device(device: BLEDevice) -> bool:
+    """Check if a device is likely a WyBot device."""
+    if not device.name:
+        return False
+    name = device.name.upper()
+    # WyBot devices advertise with MAC address as name (12 hex chars)
+    if len(name) == 12 and all(c in "0123456789ABCDEF" for c in name):
+        return True
+    # DS20 Solar Dock format: "DS20-XXXXXXXXXXXX"
+    if name.startswith("DS20-"):
+        return True
+    # Also check for "WyBot" prefix
+    if "WYBOT" in name:
+        return True
+    return False
+
+
+class BLETestClient:
+    """BLE test client for WyBot devices."""
+
+    def __init__(self):
+        self.notifications: list[dict] = []
+        self.notification_event = asyncio.Event()
+
+    def _notification_handler(self, sender, data: bytearray) -> None:
+        """Handle BLE notifications."""
+        notification = {
+            "time": time.time(),
+            "sender": str(sender),
+            "data_hex": data.hex(),
+            "data_raw": bytes(data),
+        }
+        self.notifications.append(notification)
+        self.notification_event.set()
+
+        _LOGGER.info(
+            "NOTIFICATION from %s: %s (%d bytes)",
+            sender,
+            data.hex(),
+            len(data),
+        )
+
+        # Try to parse as JSON
+        try:
+            json_data = json.loads(data.decode("utf-8"))
+            _LOGGER.info("  Parsed JSON: %s", json.dumps(json_data, indent=2))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # Try to parse as binary DP data
+            self._parse_binary_response(data)
+
+    def _parse_binary_response(self, data: bytes) -> None:
+        """Parse binary DP response."""
+        if len(data) < 3:
+            return
+
+        # Check for headers
+        if data[:2] == b"\xaa\x55":
+            _LOGGER.info("  Header: AA55 (WyBot format)")
+            if len(data) > 5:
+                payload_len = (data[4] << 8) | data[5]
+                _LOGGER.info("  Payload length: %d", payload_len)
+                self._parse_dp_data(data[6:])
+        elif data[:2] == b"\x55\xaa":
+            _LOGGER.info("  Header: 55AA (Tuya format)")
+            self._parse_dp_data(data[6:])
+        else:
+            _LOGGER.info("  No header, trying raw DP parse")
+            self._parse_dp_data(data)
+
+    def _parse_dp_data(self, data: bytes) -> None:
+        """Parse DP data entries."""
+        offset = 0
+        dp_count = 0
+
+        while offset < len(data) - 2:
+            dp_id = data[offset]
+            dp_type = data[offset + 1]
+            dp_len = data[offset + 2]
+            dp_data_start = offset + 3
+
+            if dp_data_start + dp_len > len(data):
+                break
+
+            dp_data = data[dp_data_start : dp_data_start + dp_len].hex()
+            dp_count += 1
+
+            _LOGGER.info(
+                "  DP[%d]: id=%d, type=%d, len=%d, data=%s",
+                dp_count,
+                dp_id,
+                dp_type,
+                dp_len,
+                dp_data,
+            )
+
+            # Interpret known DPs
+            self._interpret_dp(dp_id, dp_type, dp_len, dp_data)
+
+            offset = dp_data_start + dp_len
+
+    def _interpret_dp(self, dp_id: int, dp_type: int, dp_len: int, dp_data: str) -> None:
+        """Interpret known DP values."""
+        interpretations = {
+            0: self._interpret_cleaning_status,
+            1: self._interpret_cleaning_mode,
+            11: self._interpret_dock,
+            50: self._interpret_battery,
+            131: self._interpret_solar_energy,
+            213: self._interpret_dock_connection_status,
+            214: self._interpret_dock_info,
+            221: self._interpret_solar_battery,
+            222: self._interpret_solar_status,
+        }
+
+        if dp_id in interpretations:
+            try:
+                interpretations[dp_id](dp_data)
+            except Exception as e:
+                _LOGGER.debug("    Error interpreting DP %d: %s", dp_id, e)
+
+    def _interpret_cleaning_status(self, data: str) -> None:
+        statuses = {"01": "Stopped", "02": "Returning", "03": "Cleaning", "04": "Returning to Dock"}
+        status = statuses.get(data, f"Unknown ({data})")
+        _LOGGER.info("    -> CleaningStatus: %s", status)
+
+    def _interpret_cleaning_mode(self, data: str) -> None:
+        modes = ["Floor", "Wall", "Wall Then Floor", "Advanced Full Pool", "Water Line", "Turbo Floor", "Eco Floor"]
+        try:
+            mode_idx = int(data, 16)
+            mode = modes[mode_idx] if mode_idx < len(modes) else f"Unknown ({mode_idx})"
+            _LOGGER.info("    -> CleaningMode: %s", mode)
+        except (ValueError, IndexError):
+            pass
+
+    def _interpret_dock(self, data: str) -> None:
+        _LOGGER.info("    -> Dock: %s", data)
+
+    def _interpret_dock_connection_status(self, data: str) -> None:
+        statuses = {"00": "Undocked", "01": "Docked"}
+        status = statuses.get(data, f"Unknown ({data})")
+        _LOGGER.info("    -> DockConnectionStatus: %s", status)
+
+    def _interpret_battery(self, data: str) -> None:
+        if len(data) >= 4:
+            charge_state = int(data[:2], 16)
+            battery_level = int(data[2:4], 16)
+            states = {0: "Not plugged", 1: "Charging", 2: "Charged"}
+            state_str = states.get(charge_state, f"Unknown ({charge_state})")
+            _LOGGER.info("    -> Battery: %d%%, State: %s", battery_level, state_str)
+
+    def _interpret_solar_energy(self, data: str) -> None:
+        if len(data) >= 8:
+            energy_wh = int.from_bytes(bytes.fromhex(data), byteorder="little")
+            _LOGGER.info("    -> SolarEnergy: %d Wh (%.2f kWh)", energy_wh, energy_wh / 1000)
+
+    def _interpret_dock_info(self, data: str) -> None:
+        dock_types = {"01": "Standard", "05": "Solar"}
+        dock_type = dock_types.get(data, f"Unknown ({data})")
+        _LOGGER.info("    -> DockType: %s", dock_type)
+
+    def _interpret_solar_battery(self, data: str) -> None:
+        if len(data) >= 4:
+            battery_pct = int(data, 16)
+            _LOGGER.info("    -> SolarDockBattery: %d%%", battery_pct)
+
+    def _interpret_solar_status(self, data: str) -> None:
+        is_charging = int(data, 16) == 1
+        _LOGGER.info("    -> SolarCharging: %s", "Yes" if is_charging else "No")
+
+
+async def scan_devices() -> list[BLEDevice]:
+    """Scan for WyBot devices."""
+    _LOGGER.info("Scanning for BLE devices (10 seconds)...")
+
+    devices = await BleakScanner.discover(timeout=10.0)
+    wybot_devices = []
+
+    _LOGGER.info("\n=== All Discovered Devices ===")
+    for device in devices:
+        is_wybot = is_wybot_device(device)
+        marker = " [WYBOT]" if is_wybot else ""
+        _LOGGER.info("  %s (%s)%s", device.name or "Unknown", device.address, marker)
+        if is_wybot:
+            wybot_devices.append(device)
+
+    _LOGGER.info("\n=== WyBot Devices Found: %d ===", len(wybot_devices))
+    for device in wybot_devices:
+        _LOGGER.info("  Name: %s", device.name)
+        _LOGGER.info("  Address: %s", device.address)
+        _LOGGER.info("")
+
+    return wybot_devices
+
+
+async def discover_services(address: str) -> dict:
+    """Discover and print all services/characteristics for a device."""
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Connecting to %s for service discovery...", address)
+
+    discovery_info = {
+        "address": address,
+        "services": [],
+        "wybot_services_found": [],
+    }
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected successfully!")
+            _LOGGER.info("\n=== Service Discovery ===")
+
+            for service in client.services:
+                service_uuid = str(service.uuid).lower()
+                is_wybot = service_uuid in KNOWN_SERVICE_UUIDS
+
+                service_info = {
+                    "uuid": service_uuid,
+                    "is_wybot": is_wybot,
+                    "characteristics": [],
+                }
+
+                marker = " [WYBOT]" if is_wybot else ""
+                _LOGGER.info("\nService: %s%s", service.uuid, marker)
+
+                if is_wybot:
+                    discovery_info["wybot_services_found"].append(service_uuid)
+
+                for char in service.characteristics:
+                    char_info = {
+                        "uuid": str(char.uuid),
+                        "properties": list(char.properties),
+                        "descriptors": [str(d.uuid) for d in char.descriptors],
+                    }
+                    service_info["characteristics"].append(char_info)
+
+                    _LOGGER.info("  Characteristic: %s", char.uuid)
+                    _LOGGER.info("    Properties: %s", ", ".join(char.properties))
+
+                    for desc in char.descriptors:
+                        _LOGGER.info("    Descriptor: %s", desc.uuid)
+
+                discovery_info["services"].append(service_info)
+
+            _LOGGER.info("\n=== Summary ===")
+            _LOGGER.info("Total services: %d", len(discovery_info["services"]))
+            _LOGGER.info("WyBot services found: %s", discovery_info["wybot_services_found"])
+
+    except Exception as e:
+        _LOGGER.error("Connection failed: %s", e)
+        discovery_info["error"] = str(e)
+
+    return discovery_info
+
+
+async def wake_device(address: str) -> bool:
+    """Wake a WyBot device via BLE connection."""
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Attempting to wake device at %s...", address)
+
+    test_client = BLETestClient()
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected! Device should be waking...")
+
+            # Find notification characteristic
+            notify_char = None
+            for service in client.services:
+                service_uuid = str(service.uuid).lower()
+                if service_uuid in KNOWN_SERVICE_UUIDS:
+                    for char in service.characteristics:
+                        if "notify" in char.properties:
+                            notify_char = char.uuid
+                            break
+                    if notify_char:
+                        break
+
+            if notify_char:
+                _LOGGER.info("Enabling notifications on %s", notify_char)
+                await client.start_notify(notify_char, test_client._notification_handler)
+
+            _LOGGER.info("Holding connection for %.1f seconds...", WAKE_HOLD_TIME)
+            await asyncio.sleep(WAKE_HOLD_TIME)
+
+            if test_client.notifications:
+                _LOGGER.info("Received %d notifications during wake", len(test_client.notifications))
+            else:
+                _LOGGER.info("No notifications received (device may have woken silently)")
+
+            _LOGGER.info("Wake sequence complete. Device should now connect to MQTT.")
+            return True
+
+    except Exception as e:
+        _LOGGER.error("Wake failed: %s", e)
+        return False
+
+
+async def query_device(address: str) -> list[dict]:
+    """Query device status via BLE."""
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Querying device status at %s...", address)
+
+    test_client = BLETestClient()
+    results = []
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+
+            # Find write and notify characteristics
+            write_char = None
+            notify_char = None
+
+            for service in client.services:
+                service_uuid = str(service.uuid).lower()
+                if service_uuid in KNOWN_SERVICE_UUIDS:
+                    for char in service.characteristics:
+                        char_uuid = str(char.uuid).lower()
+                        if "notify" in char.properties and not notify_char:
+                            notify_char = char.uuid
+                        if ("write" in char.properties or "write-without-response" in char.properties) and not write_char:
+                            write_char = char.uuid
+
+            if notify_char:
+                _LOGGER.info("Enabling notifications on %s", notify_char)
+                await client.start_notify(notify_char, test_client._notification_handler)
+
+            if write_char:
+                # Send query command for key DPs
+                query_dps = [0, 1, 11, 50, 131, 209, 212, 213, 214, 221, 222]
+                query_cmd = json.dumps(
+                    {
+                        "ts": int(time.time()),
+                        "cmd": 9,
+                        "dp": [{"id": dp_id} for dp_id in query_dps],
+                    },
+                    separators=(",", ":"),
+                ).encode()
+
+                _LOGGER.info("Sending query command: %s", query_cmd.decode())
+                await client.write_gatt_char(write_char, query_cmd, response=True)
+                _LOGGER.info("Query sent, waiting for response...")
+
+                # Wait for responses
+                await asyncio.sleep(3.0)
+
+                results = test_client.notifications
+                _LOGGER.info("Received %d notification(s)", len(results))
+            else:
+                _LOGGER.warning("No writable characteristic found")
+
+    except Exception as e:
+        _LOGGER.error("Query failed: %s", e)
+
+    return results
+
+
+async def monitor_device(address: str, duration: int = 30) -> list[dict]:
+    """Monitor BLE notifications from a device."""
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Monitoring device at %s for %d seconds...", address, duration)
+
+    test_client = BLETestClient()
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+
+            # Enable notifications on all WyBot characteristics
+            for service in client.services:
+                service_uuid = str(service.uuid).lower()
+                if service_uuid in KNOWN_SERVICE_UUIDS:
+                    for char in service.characteristics:
+                        if "notify" in char.properties:
+                            _LOGGER.info("Enabling notifications on %s", char.uuid)
+                            try:
+                                await client.start_notify(char.uuid, test_client._notification_handler)
+                            except Exception as e:
+                                _LOGGER.warning("Failed to enable notifications on %s: %s", char.uuid, e)
+
+            _LOGGER.info("\nMonitoring for %d seconds (press Ctrl+C to stop)...\n", duration)
+
+            # Wait and collect notifications
+            start_time = time.time()
+            while time.time() - start_time < duration:
+                await asyncio.sleep(1.0)
+                elapsed = int(time.time() - start_time)
+                if elapsed % 10 == 0:
+                    _LOGGER.info("  [%d/%d seconds] Notifications received: %d", elapsed, duration, len(test_client.notifications))
+
+            _LOGGER.info("\n=== Monitoring Complete ===")
+            _LOGGER.info("Total notifications: %d", len(test_client.notifications))
+
+    except Exception as e:
+        _LOGGER.error("Monitoring failed: %s", e)
+
+    return test_client.notifications
+
+
+async def send_dp_command(
+    address: str,
+    dp_id: int,
+    dp_type: int,
+    dp_len: int,
+    dp_data: str,
+    description: str = "command",
+) -> tuple[bool, list[dict]]:
+    """Send a DP command and wait for response.
+
+    Args:
+        address: Device MAC address or BLE name
+        dp_id: Data Point ID
+        dp_type: Data Point type (4 = enum)
+        dp_len: Data length
+        dp_data: Hex string data to send
+        description: Human-readable description for logging
+
+    Returns:
+        Tuple of (success, notifications)
+    """
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Sending %s to %s...", description, address)
+
+    test_client = BLETestClient()
+    success = False
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+
+            # Find write and notify characteristics
+            write_char = None
+            notify_char = None
+
+            for service in client.services:
+                service_uuid = str(service.uuid).lower()
+                if service_uuid in KNOWN_SERVICE_UUIDS:
+                    for char in service.characteristics:
+                        char_uuid = str(char.uuid).lower()
+                        if "notify" in char.properties and not notify_char:
+                            notify_char = char.uuid
+                        if ("write" in char.properties or "write-without-response" in char.properties) and not write_char:
+                            write_char = char.uuid
+
+            if notify_char:
+                _LOGGER.info("Enabling notifications on %s", notify_char)
+                await client.start_notify(notify_char, test_client._notification_handler)
+
+            if write_char:
+                # Build command
+                cmd = json.dumps(
+                    {
+                        "ts": int(time.time()),
+                        "cmd": 4,
+                        "dp": [{"id": dp_id, "type": dp_type, "len": dp_len, "data": dp_data}],
+                    },
+                    separators=(",", ":"),
+                ).encode()
+
+                _LOGGER.info("Sending command: %s", cmd.decode())
+                await client.write_gatt_char(write_char, cmd, response=True)
+                _LOGGER.info("Command sent, waiting for response...")
+
+                # Wait for response
+                await asyncio.sleep(3.0)
+
+                if test_client.notifications:
+                    _LOGGER.info("Received %d notification(s)", len(test_client.notifications))
+                    success = True
+                else:
+                    _LOGGER.warning("No response received")
+            else:
+                _LOGGER.warning("No writable characteristic found")
+
+    except Exception as e:
+        _LOGGER.error("%s failed: %s", description, e)
+
+    return success, test_client.notifications
+
+
+async def start_cleaning(address: str, mode: int = 0) -> bool:
+    """Send start cleaning command via BLE.
+
+    Args:
+        address: Device MAC address or BLE name
+        mode: Cleaning mode (0=Floor, 1=Wall, 2=Wall Then Floor, etc)
+
+    Returns:
+        True if command was sent successfully
+    """
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Starting cleaning on %s (mode=%d)...", address, mode)
+
+    test_client = BLETestClient()
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+
+            # Find write and notify characteristics
+            write_char = None
+            notify_char = None
+
+            for service in client.services:
+                service_uuid = str(service.uuid).lower()
+                if service_uuid in KNOWN_SERVICE_UUIDS:
+                    for char in service.characteristics:
+                        char_uuid = str(char.uuid).lower()
+                        if "notify" in char.properties and not notify_char:
+                            notify_char = char.uuid
+                        if ("write" in char.properties or "write-without-response" in char.properties) and not write_char:
+                            write_char = char.uuid
+
+            if notify_char:
+                _LOGGER.info("Enabling notifications on %s", notify_char)
+                await client.start_notify(notify_char, test_client._notification_handler)
+
+            if not write_char:
+                _LOGGER.error("No writable characteristic found")
+                return False
+
+            # First, query current state to check dock status
+            query_cmd = json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "cmd": 9,
+                    "dp": [{"id": 0}, {"id": 213}],  # CleaningStatus, DockConnectionStatus
+                },
+                separators=(",", ":"),
+            ).encode()
+
+            _LOGGER.info("Querying current state: %s", query_cmd.decode())
+            await client.write_gatt_char(write_char, query_cmd, response=True)
+            await asyncio.sleep(2.0)
+
+            # Check if docked (warn user)
+            for notification in test_client.notifications:
+                data = notification.get("data_raw", b"")
+                # Look for DP 213 = 01 (docked)
+                if b"\xd5\x04\x01\x01" in data:  # DP 213, type 4, len 1, value 01
+                    _LOGGER.warning("=" * 60)
+                    _LOGGER.warning("⚠️  Robot is DOCKED on Solar Dock (DP 213 = 01)")
+                    _LOGGER.warning("⚠️  KNOWN LIMITATION: BLE start cleaning commands are")
+                    _LOGGER.warning("⚠️  IGNORED when robot is docked on DS20 Solar Dock.")
+                    _LOGGER.warning("⚠️  ")
+                    _LOGGER.warning("⚠️  Workaround: Use the WyBot mobile app to start cleaning,")
+                    _LOGGER.warning("⚠️  or manually remove the robot from the dock first.")
+                    _LOGGER.warning("=" * 60)
+
+            # Set mode first if not default
+            if mode != 0:
+                mode_hex = f"{mode:02x}"
+                mode_cmd = json.dumps(
+                    {
+                        "ts": int(time.time()),
+                        "cmd": 4,
+                        "dp": [{"id": 1, "type": 4, "len": 1, "data": mode_hex}],
+                    },
+                    separators=(",", ":"),
+                ).encode()
+                _LOGGER.info("Setting cleaning mode to %d: %s", mode, mode_cmd.decode())
+                await client.write_gatt_char(write_char, mode_cmd, response=True)
+                await asyncio.sleep(1.0)
+
+            # Send start cleaning command: DP 0 = 03
+            start_cmd = json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "cmd": 4,
+                    "dp": [{"id": 0, "type": 4, "len": 1, "data": "03"}],
+                },
+                separators=(",", ":"),
+            ).encode()
+
+            _LOGGER.info("Sending start cleaning: %s", start_cmd.decode())
+            await client.write_gatt_char(write_char, start_cmd, response=True)
+
+            # Wait for response
+            await asyncio.sleep(3.0)
+
+            _LOGGER.info("Received %d notification(s)", len(test_client.notifications))
+            _LOGGER.info("Start cleaning command sent. Check robot behavior.")
+            return True
+
+    except Exception as e:
+        _LOGGER.error("Start cleaning failed: %s", e)
+        return False
+
+
+async def stop_cleaning(address: str) -> bool:
+    """Send stop cleaning command via BLE.
+
+    Args:
+        address: Device MAC address or BLE name
+
+    Returns:
+        True if command was sent successfully
+    """
+    success, _ = await send_dp_command(
+        address,
+        dp_id=0,
+        dp_type=4,
+        dp_len=1,
+        dp_data="01",  # 01 = Stopped
+        description="stop cleaning (DP 0 = 01)",
+    )
+    return success
+
+
+async def start_cleaning_binary(address: str) -> bool:
+    """Send start cleaning command using binary format to EE01.
+
+    This is the CORRECT method discovered via PacketLogger capture.
+    The WyBot app uses binary AA55 format sent to EE01 characteristic.
+
+    Args:
+        address: Device MAC address or BLE name
+
+    Returns:
+        True if robot started cleaning
+    """
+    address = ble_name_to_mac(address)
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("START CLEANING (Binary format to EE01)")
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("Connecting to %s...", address)
+
+    success = False
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+
+            # Set up notification handler
+            cleaning_started = False
+            undocked = False
+
+            def handle_notify(sender, data: bytearray) -> None:
+                nonlocal cleaning_started, undocked
+                if b"\x00\x04\x01\x03" in data:
+                    cleaning_started = True
+                    _LOGGER.info(">>> CleaningStatus: CLEANING! <<<")
+                if b"\xd5\x04\x01\x00" in data:
+                    undocked = True
+                    _LOGGER.info(">>> DockStatus: UNDOCKED! <<<")
+
+            # Enable notifications on FF01 (status updates)
+            _LOGGER.info("Enabling notifications on FF01...")
+            await client.start_notify(CHAR_UUID_FF01_NOTIFY, handle_notify)
+            await asyncio.sleep(2)
+
+            # Send binary command to EE01
+            _LOGGER.info("Sending binary command to EE01: %s", BINARY_CMD_START_CLEANING.hex())
+            await client.write_gatt_char(CHAR_UUID_EE01_WRITE, BINARY_CMD_START_CLEANING, response=True)
+            _LOGGER.info("Command sent!")
+
+            # Wait for response
+            _LOGGER.info("Waiting for status update...")
+            await asyncio.sleep(5)
+
+            if cleaning_started:
+                _LOGGER.info("=" * 60)
+                _LOGGER.info("SUCCESS! Robot is cleaning!")
+                _LOGGER.info("=" * 60)
+                success = True
+            elif undocked:
+                _LOGGER.info("Robot undocked but cleaning status not confirmed")
+                success = True
+            else:
+                _LOGGER.warning("No status change detected")
+
+    except Exception as e:
+        _LOGGER.error("Error: %s", e)
+
+    return success
+
+
+async def stop_cleaning_binary(address: str) -> bool:
+    """Send stop cleaning command using binary format to EE01."""
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Stopping cleaning (binary format to EE01)...")
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+            await client.write_gatt_char(CHAR_UUID_EE01_WRITE, BINARY_CMD_STOP_CLEANING, response=True)
+            _LOGGER.info("Stop command sent: %s", BINARY_CMD_STOP_CLEANING.hex())
+            await asyncio.sleep(2)
+            return True
+    except Exception as e:
+        _LOGGER.error("Error: %s", e)
+        return False
+
+
+def build_binary_query(dp_id: int) -> bytes:
+    """Build a binary query command for a single DP."""
+    # Query format: aa55 + cmd(0009) + len_le + dp_id + checksum
+    header = b'\xaa\x55'
+    cmd = b'\x00\x09'  # Query command
+    length = b'\x01\x00'  # 1 byte payload, little-endian
+    payload = bytes([dp_id])
+    packet = header + cmd + length + payload
+    checksum = (sum(packet[2:]) - 1) & 0xFF  # Checksum pattern: sum - 1
+    return packet + bytes([checksum])
+
+
+async def query_device_binary(address: str) -> dict:
+    """Query device status via BLE using binary format.
+
+    Returns dict of DP values.
+    """
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Querying device status (binary format)...")
+
+    results = {}
+
+    # DPs to query
+    query_dps = [0, 1, 11, 50, 131, 209, 212, 213, 214, 221, 222]
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+
+            # Notification handler to capture responses
+            def handle_notify(sender, data: bytearray):
+                hex_data = data.hex()
+                # Parse DP responses
+                if data[:2] == b'\xaa\x55' and len(data) > 6:
+                    # Skip header (2) + cmd (2) + len (2)
+                    payload = data[6:-1]  # Exclude checksum
+                    offset = 0
+                    while offset < len(payload) - 2:
+                        dp_id = payload[offset]
+                        dp_type = payload[offset + 1]
+                        dp_len = payload[offset + 2]
+                        if offset + 3 + dp_len <= len(payload):
+                            dp_data = payload[offset + 3:offset + 3 + dp_len].hex()
+                            results[dp_id] = {"type": dp_type, "len": dp_len, "data": dp_data}
+                            _LOGGER.info("  DP %d: %s", dp_id, dp_data)
+                        offset += 3 + dp_len
+
+            await client.start_notify(CHAR_UUID_FF01_NOTIFY, handle_notify)
+            await asyncio.sleep(1)
+
+            # Query each DP
+            for dp_id in query_dps:
+                query_cmd = build_binary_query(dp_id)
+                await client.write_gatt_char(CHAR_UUID_EE01_WRITE, query_cmd, response=True)
+                await asyncio.sleep(0.3)
+
+            await asyncio.sleep(2)
+
+            # Interpret results
+            _LOGGER.info("\n=== Status Summary ===")
+            if 0 in results:
+                status_map = {"01": "Stopped", "02": "Returning", "03": "Cleaning", "04": "Returning to Dock"}
+                _LOGGER.info("CleaningStatus: %s", status_map.get(results[0]["data"], results[0]["data"]))
+            if 1 in results:
+                mode_map = {0: "Floor", 1: "Wall", 2: "Wall Then Floor", 3: "Advanced Full Pool",
+                           4: "Water Line", 5: "Turbo Floor", 6: "Eco Floor"}
+                mode_val = int(results[1]["data"], 16)
+                _LOGGER.info("CleaningMode: %s", mode_map.get(mode_val, f"Unknown ({mode_val})"))
+            if 50 in results:
+                data = results[50]["data"]
+                if len(data) >= 4:
+                    charge = int(data[:2], 16)
+                    level = int(data[2:4], 16)
+                    charge_map = {0: "Not plugged", 1: "Charging", 2: "Charged"}
+                    _LOGGER.info("Battery: %d%%, %s", level, charge_map.get(charge, f"Unknown ({charge})"))
+            if 213 in results:
+                dock_map = {"00": "Undocked", "01": "Docked"}
+                _LOGGER.info("DockStatus: %s", dock_map.get(results[213]["data"], results[213]["data"]))
+            if 221 in results:
+                data = results[221]["data"]
+                if len(data) >= 4:
+                    battery_pct = int(data[2:4], 16)
+                    _LOGGER.info("SolarDockBattery: %d%%", battery_pct)
+
+    except Exception as e:
+        _LOGGER.error("Query failed: %s", e)
+
+    return results
+
+
+async def set_mode_binary(address: str, mode: int) -> bool:
+    """Set cleaning mode using binary format to EE01.
+
+    Args:
+        address: Device MAC address or BLE name
+        mode: Cleaning mode (0-6)
+            0 = Floor
+            1 = Wall
+            2 = Wall Then Floor
+            3 = Advanced Full Pool
+            4 = Water Line
+            5 = Turbo Floor
+            6 = Eco Floor
+
+    Returns:
+        True if command was sent successfully
+    """
+    address = ble_name_to_mac(address)
+
+    if mode not in BINARY_MODE_COMMANDS:
+        _LOGGER.error("Invalid mode %d. Must be 0-6.", mode)
+        return False
+
+    mode_name = MODE_NAMES.get(mode, f"Unknown ({mode})")
+    cmd = BINARY_MODE_COMMANDS[mode]
+
+    _LOGGER.info("Setting cleaning mode to %d (%s)...", mode, mode_name)
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+            await client.write_gatt_char(CHAR_UUID_EE01_WRITE, cmd, response=True)
+            _LOGGER.info("Mode command sent: %s", cmd.hex())
+            await asyncio.sleep(2)
+            _LOGGER.info("Mode set to %s", mode_name)
+            return True
+    except Exception as e:
+        _LOGGER.error("Error: %s", e)
+        return False
+
+
+async def return_to_dock_binary(address: str) -> bool:
+    """Send return to dock command using binary format to EE01.
+
+    Sends DP 11 = 01 which triggers status 04 (Returning to Dock).
+    """
+    address = ble_name_to_mac(address)
+    _LOGGER.info("Sending return to dock (binary format to EE01)...")
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+            await client.write_gatt_char(CHAR_UUID_EE01_WRITE, BINARY_CMD_RETURN_TO_DOCK, response=True)
+            _LOGGER.info("Return command sent: %s", BINARY_CMD_RETURN_TO_DOCK.hex())
+            await asyncio.sleep(2)
+            _LOGGER.info("Robot should now be returning to dock (status 04)")
+            return True
+    except Exception as e:
+        _LOGGER.error("Error: %s", e)
+        return False
+
+
+async def undock_device(address: str) -> bool:
+    """Send undock/return command via BLE.
+
+    This makes the robot leave the dock. The robot should undock and
+    be ready to receive cleaning commands.
+
+    Args:
+        address: Device MAC address or BLE name
+
+    Returns:
+        True if command was sent successfully
+    """
+    success, _ = await send_dp_command(
+        address,
+        dp_id=11,
+        dp_type=4,
+        dp_len=1,
+        dp_data="01",  # 01 = Return/Undock
+        description="undock (DP 11 = 01)",
+    )
+    return success
+
+
+async def full_clean(address: str, mode: int = 0, undock_wait: int = 10) -> bool:
+    """Execute full cleaning sequence: undock, wait, start cleaning.
+
+    This is the recommended sequence when robot is docked:
+    1. Send undock command (DP 11 = 01)
+    2. Wait for robot to undock
+    3. Verify undocked state (DP 213 = 00)
+    4. Send start cleaning command (DP 0 = 03)
+
+    Args:
+        address: Device MAC address or BLE name
+        mode: Cleaning mode (0=Floor, 1=Wall, etc)
+        undock_wait: Seconds to wait after undock command
+
+    Returns:
+        True if cleaning started successfully
+    """
+    address = ble_name_to_mac(address)
+    _LOGGER.info("=" * 60)
+    _LOGGER.info("FULL CLEAN SEQUENCE: %s", address)
+    _LOGGER.info("=" * 60)
+
+    test_client = BLETestClient()
+
+    try:
+        async with BleakClient(address, timeout=CONNECTION_TIMEOUT) as client:
+            _LOGGER.info("Connected!")
+
+            # Find write and notify characteristics
+            write_char = None
+            notify_char = None
+
+            for service in client.services:
+                service_uuid = str(service.uuid).lower()
+                if service_uuid in KNOWN_SERVICE_UUIDS:
+                    for char in service.characteristics:
+                        char_uuid = str(char.uuid).lower()
+                        if "notify" in char.properties and not notify_char:
+                            notify_char = char.uuid
+                        if ("write" in char.properties or "write-without-response" in char.properties) and not write_char:
+                            write_char = char.uuid
+
+            if notify_char:
+                await client.start_notify(notify_char, test_client._notification_handler)
+
+            if not write_char:
+                _LOGGER.error("No writable characteristic found")
+                return False
+
+            # Step 1: Query current state
+            _LOGGER.info("\n[Step 1] Querying current state...")
+            query_cmd = json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "cmd": 9,
+                    "dp": [{"id": 0}, {"id": 11}, {"id": 50}, {"id": 213}],
+                },
+                separators=(",", ":"),
+            ).encode()
+            await client.write_gatt_char(write_char, query_cmd, response=True)
+            await asyncio.sleep(2.0)
+
+            # Check initial dock status
+            is_docked = True  # Assume docked initially
+            for notification in test_client.notifications:
+                data = notification.get("data_raw", b"")
+                if b"\xd5\x04\x01\x00" in data:  # DP 213 = 00 (undocked)
+                    is_docked = False
+                    _LOGGER.info("Robot is already UNDOCKED")
+
+            if is_docked:
+                _LOGGER.info("Robot is DOCKED - will send undock command")
+
+            # Step 2: Send undock command
+            _LOGGER.info("\n[Step 2] Sending undock command (DP 11 = 01)...")
+            undock_cmd = json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "cmd": 4,
+                    "dp": [{"id": 11, "type": 4, "len": 1, "data": "01"}],
+                },
+                separators=(",", ":"),
+            ).encode()
+            _LOGGER.info("Command: %s", undock_cmd.decode())
+            await client.write_gatt_char(write_char, undock_cmd, response=True)
+            await asyncio.sleep(2.0)
+
+            # Step 3: Wait for robot to undock
+            _LOGGER.info("\n[Step 3] Waiting %d seconds for robot to undock...", undock_wait)
+            for i in range(undock_wait):
+                await asyncio.sleep(1.0)
+                _LOGGER.info("  Waiting... %d/%d seconds", i + 1, undock_wait)
+
+            # Step 4: Verify undocked state
+            _LOGGER.info("\n[Step 4] Verifying undocked state...")
+            test_client.notifications.clear()
+            query_cmd = json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "cmd": 9,
+                    "dp": [{"id": 0}, {"id": 213}],
+                },
+                separators=(",", ":"),
+            ).encode()
+            await client.write_gatt_char(write_char, query_cmd, response=True)
+            await asyncio.sleep(2.0)
+
+            # Check dock status after undock
+            still_docked = True
+            for notification in test_client.notifications:
+                data = notification.get("data_raw", b"")
+                if b"\xd5\x04\x01\x00" in data:  # DP 213 = 00 (undocked)
+                    still_docked = False
+                    _LOGGER.info("✓ Robot confirmed UNDOCKED (DP 213 = 00)")
+
+            if still_docked:
+                _LOGGER.warning("⚠️  Robot may still be docked - proceeding anyway")
+
+            # Step 5: Set cleaning mode if needed
+            if mode != 0:
+                _LOGGER.info("\n[Step 5] Setting cleaning mode to %d...", mode)
+                mode_hex = f"{mode:02x}"
+                mode_cmd = json.dumps(
+                    {
+                        "ts": int(time.time()),
+                        "cmd": 4,
+                        "dp": [{"id": 1, "type": 4, "len": 1, "data": mode_hex}],
+                    },
+                    separators=(",", ":"),
+                ).encode()
+                await client.write_gatt_char(write_char, mode_cmd, response=True)
+                await asyncio.sleep(1.0)
+
+            # Step 6: Send start cleaning command
+            _LOGGER.info("\n[Step 6] Sending start cleaning command (DP 0 = 03)...")
+            test_client.notifications.clear()
+            start_cmd = json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "cmd": 4,
+                    "dp": [{"id": 0, "type": 4, "len": 1, "data": "03"}],
+                },
+                separators=(",", ":"),
+            ).encode()
+            _LOGGER.info("Command: %s", start_cmd.decode())
+            await client.write_gatt_char(write_char, start_cmd, response=True)
+            await asyncio.sleep(3.0)
+
+            # Step 7: Verify cleaning started
+            _LOGGER.info("\n[Step 7] Verifying cleaning started...")
+            test_client.notifications.clear()
+            query_cmd = json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "cmd": 9,
+                    "dp": [{"id": 0}, {"id": 213}],
+                },
+                separators=(",", ":"),
+            ).encode()
+            await client.write_gatt_char(write_char, query_cmd, response=True)
+            await asyncio.sleep(2.0)
+
+            is_cleaning = False
+            for notification in test_client.notifications:
+                data = notification.get("data_raw", b"")
+                if b"\x00\x04\x01\x03" in data:  # DP 0 = 03 (cleaning)
+                    is_cleaning = True
+                    _LOGGER.info("✓ Robot confirmed CLEANING (DP 0 = 03)")
+
+            _LOGGER.info("\n" + "=" * 60)
+            if is_cleaning:
+                _LOGGER.info("SUCCESS: Full clean sequence completed - robot is cleaning!")
+            else:
+                _LOGGER.info("RESULT: Commands sent. Check robot behavior.")
+                _LOGGER.info("        (Response verification may not detect all states)")
+            _LOGGER.info("=" * 60)
+
+            return True
+
+    except Exception as e:
+        _LOGGER.error("Full clean sequence failed: %s", e)
+        return False
+
+
+async def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="WyBot BLE Test Script")
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # Scan command
+    subparsers.add_parser("scan", help="Scan for WyBot devices")
+
+    # Discover command
+    discover_parser = subparsers.add_parser("discover", help="Discover services on a device")
+    discover_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Wake command
+    wake_parser = subparsers.add_parser("wake", help="Wake a device via BLE")
+    wake_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Query command
+    query_parser = subparsers.add_parser("query", help="Query device status")
+    query_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Monitor command
+    monitor_parser = subparsers.add_parser("monitor", help="Monitor device notifications")
+    monitor_parser.add_argument("address", help="Device MAC address or BLE name")
+    monitor_parser.add_argument("duration", nargs="?", type=int, default=30, help="Duration in seconds (default: 30)")
+
+    # Start cleaning command
+    start_parser = subparsers.add_parser("start", help="Start cleaning")
+    start_parser.add_argument("address", help="Device MAC address or BLE name")
+    start_parser.add_argument(
+        "--mode",
+        type=int,
+        default=0,
+        help="Cleaning mode: 0=Floor, 1=Wall, 2=Wall Then Floor, 3=Advanced Full Pool, 4=Water Line, 5=Turbo Floor, 6=Eco Floor (default: 0)",
+    )
+
+    # Stop cleaning command
+    stop_parser = subparsers.add_parser("stop", help="Stop cleaning")
+    stop_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Undock command
+    undock_parser = subparsers.add_parser("undock", help="Undock robot from dock")
+    undock_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Full clean command
+    full_clean_parser = subparsers.add_parser("full-clean", help="Full sequence: undock, wait, start cleaning")
+    full_clean_parser.add_argument("address", help="Device MAC address or BLE name")
+    full_clean_parser.add_argument(
+        "--mode",
+        type=int,
+        default=0,
+        help="Cleaning mode: 0=Floor, 1=Wall, etc. (default: 0)",
+    )
+    full_clean_parser.add_argument(
+        "--wait",
+        type=int,
+        default=10,
+        help="Seconds to wait after undock before starting (default: 10)",
+    )
+
+    # Start cleaning (binary format) - VERIFIED WORKING
+    start_binary_parser = subparsers.add_parser(
+        "start-binary",
+        help="Start cleaning using binary format to EE01 (VERIFIED WORKING - use this!)",
+    )
+    start_binary_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Stop cleaning (binary format)
+    stop_binary_parser = subparsers.add_parser(
+        "stop-binary",
+        help="Stop cleaning using binary format to EE01",
+    )
+    stop_binary_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Return to dock (binary format)
+    return_binary_parser = subparsers.add_parser(
+        "return-binary",
+        help="Return to dock using binary format to EE01",
+    )
+    return_binary_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    # Set cleaning mode (binary format)
+    mode_parser = subparsers.add_parser(
+        "set-mode",
+        help="Set cleaning mode (0=Floor, 1=Wall, 2=Wall Then Floor, 3=Advanced, 4=Water Line, 5=Turbo, 6=Eco)",
+    )
+    mode_parser.add_argument("address", help="Device MAC address or BLE name")
+    mode_parser.add_argument("mode", type=int, choices=range(7), help="Mode 0-6")
+
+    # Query (binary format)
+    query_binary_parser = subparsers.add_parser(
+        "query-binary",
+        help="Query device status using binary format (shows cleaning mode)",
+    )
+    query_binary_parser.add_argument("address", help="Device MAC address or BLE name")
+
+    args = parser.parse_args()
+
+    if args.command == "scan":
+        await scan_devices()
+    elif args.command == "discover":
+        await discover_services(args.address)
+    elif args.command == "wake":
+        await wake_device(args.address)
+    elif args.command == "query":
+        await query_device(args.address)
+    elif args.command == "monitor":
+        await monitor_device(args.address, args.duration)
+    elif args.command == "start":
+        await start_cleaning(args.address, args.mode)
+    elif args.command == "stop":
+        await stop_cleaning(args.address)
+    elif args.command == "undock":
+        await undock_device(args.address)
+    elif args.command == "full-clean":
+        await full_clean(args.address, args.mode, args.wait)
+    elif args.command == "start-binary":
+        await start_cleaning_binary(args.address)
+    elif args.command == "stop-binary":
+        await stop_cleaning_binary(args.address)
+    elif args.command == "return-binary":
+        await return_to_dock_binary(args.address)
+    elif args.command == "set-mode":
+        await set_mode_binary(args.address, args.mode)
+    elif args.command == "query-binary":
+        await query_device_binary(args.address)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        _LOGGER.info("\nInterrupted by user")


### PR DESCRIPTION
## Summary

- Migrate from `pydantic.v1` compat layer to native pydantic v2 API — the v1 compat layer is broken on Python 3.14 (HA 2026.1+), causing the integration to fail with `RuntimeError: no validator found for UndefinedType`
- Add explicit `= None` defaults for optional fields (pydantic v2 behavior change)
- Move `TypeVar` from model class bodies to module level (v2 would interpret as fields)
- Clean up manifest.json: remove empty `ssdp`, `homekit`, `zeroconf` keys; add `integration_type`

## Test plan

- [x] All pydantic models import successfully with pydantic v2
- [x] API response parsing (DevicesResponse with nested Device/Docker/Vision)
- [x] MQTT command parsing (Command with full and sparse DPs)
- [x] Optional field handling (Group without docker, LoginResponse without metadata)
- [x] GenericDP.dict() produces correct command payloads
- [x] Group.get_dp() resolves Battery, CleaningStatus, SolarEnergy correctly
- [x] camelCase alias resolution works for all API models
- [ ] Deploy to HA 2026.1+ and verify integration loads and entities update