### PR TITLE
Reach Gold quality scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,91 @@ The integration uses a **BLE-first with MQTT fallback** architecture:
 
 Commands (start, stop, return to dock) are also sent via BLE first, falling back to MQTT if needed.
 
+## Supported functionality
+
+Each WyBot robot (and its dock, if present) is exposed as one or more Home Assistant devices with the following platforms. See the [Entities](#entities) tables above for the full per-entity breakdown.
+
+- **`vacuum`** — Start, stop, and return-to-dock control, plus cleaning-mode selection (7 modes).
+- **`sensor`** — Robot and dock battery levels, solar energy harvested, dock type, data source (Bluetooth/Cloud), and last-communication timestamps.
+- **`binary_sensor`** — Robot charging and solar-dock charging status.
+- **`button`** — Send WiFi credentials to the dock via Bluetooth (diagnostic, disabled by default).
+
+## Use cases
+
+- **Scheduled nightly cleaning** — Automatically start the robot on a floor-cleaning cycle each night (or on your preferred days) so the pool is ready in the morning.
+- **Notify when cleaning completes** — Send a phone notification when the robot finishes and returns to the dock, so you know it's done without checking the pool.
+- **Return to dock on low battery** — Trigger a return-to-dock (or a reminder) when the robot battery drops below a threshold to avoid it stranding mid-pool.
+- **Dashboard status at a glance** — Show battery level, charging status, solar energy harvested, and the current data source (Bluetooth vs. Cloud) on a Lovelace dashboard.
+
+## Example automations
+
+These are copy-pasteable starting points. Replace the `entity_id` values with the ones created for your device (find them under **Settings → Devices & Services → WyBot**, or in **Developer Tools → States**).
+
+**Start cleaning every day at 8am**
+
+```yaml
+alias: WyBot - Start cleaning at 8am
+triggers:
+  - trigger: time
+    at: "08:00:00"
+actions:
+  - action: vacuum.start
+    target:
+      entity_id: vacuum.wybot_s2_pro
+mode: single
+```
+
+**Notify when the robot battery is fully charged**
+
+```yaml
+alias: WyBot - Notify when battery full
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.wybot_s2_pro_robot_battery
+    above: 99
+actions:
+  - action: notify.notify
+    data:
+      title: WyBot
+      message: The pool robot is fully charged and ready to clean.
+mode: single
+```
+
+> A ready-made blueprint that bundles scheduling, completion notifications, and battery alerts is described under [Blueprints](#blueprints) below.
+
+## Known limitations
+
+- **The robot goes offline underwater** — WyBot robots disconnect from WiFi when submerged. The dock stays online and relays commands to the robot via Bluetooth, so control while the robot is in the water depends on the dock being powered and in BLE range.
+- **Cloud dependency for remote control** — When the dock is out of Bluetooth range of your Home Assistant host, the integration falls back to WyBot's cloud MQTT broker. Remote control and status updates then depend on WyBot's cloud service being reachable.
+- **Dock must be set up before the robot** — WiFi provisioning happens on the dock before the robot is paired. See [Setting Up a WyBot S2 Pro with a Dock](#setting-up-a-wybot-s2-pro-with-a-dock) — there is no way to configure the dock's WiFi after the robot has been paired.
+- **Bluetooth range** — BLE-first operation requires the dock to be within Bluetooth range of your Home Assistant host or a Bluetooth proxy. Outside that range the integration relies on the cloud fallback.
+
+## Troubleshooting
+
+**A device shows as `unavailable`**
+- Check that the dock is powered on and within Bluetooth range of your Home Assistant host (or a Bluetooth proxy).
+- If relying on the cloud fallback, confirm your Home Assistant host has internet access and WyBot's cloud service is reachable.
+- Check the **Data source** and **Last BLE/MQTT communication** diagnostic sensors to see how (and when) the device was last reached.
+
+**Commands (start/stop/return to dock) don't work**
+- Commands are sent over Bluetooth first, then the cloud. If the dock is at the edge of BLE range, try again — a transient BLE write can fail and the next attempt often succeeds.
+- Confirm the dock is online (see above) and that the robot is docked or in the water within range of the dock.
+
+**A reauthentication prompt appears**
+- If your WyBot password changes, Home Assistant raises a **Reauthenticate** notification. Open it and enter the new password; the entry reloads automatically. See [Reauthentication](#reauthentication).
+
+**Enabling debug logging**
+
+Add the following to your `configuration.yaml` and restart Home Assistant to capture detailed logs for bug reports:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.wybot: debug
+    wybot: debug
+```
+
 ## Setting Up a WyBot S2 Pro with a Dock
 
 > **⚠️ Important:** The dock must be set up **before** the robot. You must first set up the dock and connect it to WiFi, then pair the robot with it. There is no way to configure WiFi on the dock after the robot has been paired.

--- a/custom_components/wybot/__init__.py
+++ b/custom_components/wybot/__init__.py
@@ -6,13 +6,14 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_WIFI_PASSWORD, CONF_WIFI_SSID
+from wybot import WyBotHTTPClient, WybotAuthError, WybotConnectionError
+
+from .const import CONF_WIFI_PASSWORD, CONF_WIFI_SSID, DOMAIN
 from .wybot_coordinator import WyBotCoordinator
-from wybot import WybotAuthError, WybotConnectionError
-from wybot import WyBotHTTPClient
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -23,6 +24,30 @@ PLATFORMS: list[Platform] = [
 _LOGGER = logging.getLogger(__name__)
 
 type WyBotConfigEntry = ConfigEntry[WyBotCoordinator]
+
+
+def _device_identifiers(coordinator: WyBotCoordinator) -> set[tuple[str, str]]:
+    """Return the device-registry identifiers currently backed by the account."""
+    identifiers: set[tuple[str, str]] = set()
+    for idx, group in coordinator.data.items():
+        identifiers.add((DOMAIN, str(idx)))
+        if getattr(group, "docker", None):
+            identifiers.add((DOMAIN, f"{idx}_dock"))
+    return identifiers
+
+
+@callback
+def _async_purge_stale_devices(
+    hass: HomeAssistant, entry: WyBotConfigEntry, coordinator: WyBotCoordinator
+) -> None:
+    """Remove registry devices no longer backed by the WyBot account."""
+    registry = dr.async_get(hass)
+    current = _device_identifiers(coordinator)
+    for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+        if not device.identifiers & current:
+            registry.async_update_device(
+                device.id, remove_config_entry_id=entry.entry_id
+            )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: WyBotConfigEntry) -> bool:
@@ -47,6 +72,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: WyBotConfigEntry) -> boo
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Remove devices that are no longer present on the account (stale-devices),
+    # now and on every subsequent coordinator update.
+    def _purge() -> None:
+        _async_purge_stale_devices(hass, entry, coordinator)
+
+    _purge()
+    entry.async_on_unload(coordinator.async_add_listener(_purge))
+
     # Stop coordinator resources (MQTT) on unload.
     entry.async_on_unload(coordinator.async_stop)
 
@@ -66,3 +99,10 @@ async def _async_update_listener(hass: HomeAssistant, entry: WyBotConfigEntry) -
 async def async_unload_entry(hass: HomeAssistant, entry: WyBotConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: WyBotConfigEntry, device: dr.DeviceEntry
+) -> bool:
+    """Allow manual removal of a device no longer provided by the account."""
+    return not device.identifiers & _device_identifiers(entry.runtime_data)

--- a/custom_components/wybot/binary_sensor.py
+++ b/custom_components/wybot/binary_sensor.py
@@ -41,18 +41,27 @@ async def async_setup_entry(
 ) -> None:
     """Set up the WyBot binary sensor platform."""
     coordinator = entry.runtime_data
+    known: set[str] = set()
 
-    entities: list[BinarySensorEntity] = []
+    @callback
+    def _add_new_devices() -> None:
+        """Add binary sensors for devices discovered after setup."""
+        entities: list[BinarySensorEntity] = []
+        for device_id in coordinator.vacuums:
+            if device_id in known:
+                continue
+            known.add(device_id)
+            entities.extend(
+                [
+                    WyBotRobotChargingBinarySensor(idx=device_id, coordinator=coordinator),
+                    WyBotDockChargingBinarySensor(idx=device_id, coordinator=coordinator),
+                ]
+            )
+        if entities:
+            async_add_entities(entities)
 
-    for device_id in coordinator.vacuums:
-        entities.extend(
-            [
-                WyBotRobotChargingBinarySensor(idx=device_id, coordinator=coordinator),
-                WyBotDockChargingBinarySensor(idx=device_id, coordinator=coordinator),
-            ]
-        )
-
-    async_add_entities(entities)
+    _add_new_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
 
 
 class WyBotBinarySensorBase(BinarySensorEntity, CoordinatorEntity):

--- a/custom_components/wybot/button.py
+++ b/custom_components/wybot/button.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -28,34 +28,43 @@ async def async_setup_entry(
     """Set up WyBot buttons from a config entry."""
     coordinator = config_entry.runtime_data
 
-    entities: list[ButtonEntity] = []
-
     # Get WiFi credentials from config entry
     wifi_ssid = config_entry.data.get(CONF_WIFI_SSID)
     wifi_password = config_entry.data.get(CONF_WIFI_PASSWORD)
+    known: set[str] = set()
 
-    # Add WiFi reconfigure button for each dock device (if credentials configured)
-    for idx in coordinator.vacuums:
-        group = coordinator.data.get(idx)
-        # Only create button if there's a dock with a BLE name and WiFi credentials
-        if (
-            group
-            and group.docker
-            and group.docker.ble_name
-            and wifi_ssid
-            and wifi_password
-        ):
-            entities.append(
-                WyBotWifiReconfigureButton(
-                    coordinator,
-                    idx,
-                    group.docker.ble_name,
-                    wifi_ssid,
-                    wifi_password,
+    @callback
+    def _add_new_devices() -> None:
+        """Add WiFi buttons for qualifying devices discovered after setup."""
+        entities: list[ButtonEntity] = []
+        # Only create a button if the device has a dock with a BLE name and
+        # WiFi credentials are configured.
+        for idx in coordinator.vacuums:
+            if idx in known:
+                continue
+            group = coordinator.data.get(idx)
+            if (
+                group
+                and group.docker
+                and group.docker.ble_name
+                and wifi_ssid
+                and wifi_password
+            ):
+                known.add(idx)
+                entities.append(
+                    WyBotWifiReconfigureButton(
+                        coordinator,
+                        idx,
+                        group.docker.ble_name,
+                        wifi_ssid,
+                        wifi_password,
+                    )
                 )
-            )
+        if entities:
+            async_add_entities(entities)
 
-    async_add_entities(entities)
+    _add_new_devices()
+    config_entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
 
 
 class WyBotWifiReconfigureButton(CoordinatorEntity[WyBotCoordinator], ButtonEntity):
@@ -114,6 +123,8 @@ class WyBotWifiReconfigureButton(CoordinatorEntity[WyBotCoordinator], ButtonEnti
         )
         if not success:
             raise HomeAssistantError(
-                f"Failed to send WiFi credentials to dock {self._ble_name} via BLE"
+                translation_domain=DOMAIN,
+                translation_key="wifi_send_failed",
+                translation_placeholders={"device": self._ble_name},
             )
         _LOGGER.info("Successfully sent WiFi credentials to dock %s", self._ble_name)

--- a/custom_components/wybot/config_flow.py
+++ b/custom_components/wybot/config_flow.py
@@ -93,7 +93,14 @@ class WyBotConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Use the MAC address as unique ID
         await self.async_set_unique_id(format_mac(discovery_info.address))
-        self._abort_if_unique_id_configured()
+        # If this dock is already configured, refresh its stored discovered
+        # address/name (they can change) instead of just aborting.
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_DISCOVERED_DEVICE_ADDRESS: discovery_info.address,
+                CONF_DISCOVERED_DEVICE_NAME: discovery_info.name,
+            }
+        )
 
         # Store discovery info for later use
         self._discovery_info = discovery_info
@@ -190,6 +197,52 @@ class WyBotConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
             description_placeholders={"username": reauth_entry.data[CONF_USERNAME]},
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Let the user change the WyBot account credentials."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                # Guard against reconfiguring to a different account, but only
+                # when the existing entry already carries a unique_id.
+                if reconfigure_entry.unique_id is not None:
+                    await self.async_set_unique_id(info["user_id"])
+                    self._abort_if_unique_id_mismatch(reason="wrong_account")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    unique_id=info["user_id"],
+                    data_updates={
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME,
+                        default=reconfigure_entry.data[CONF_USERNAME],
+                    ): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
             errors=errors,
         )
 

--- a/custom_components/wybot/diagnostics.py
+++ b/custom_components/wybot/diagnostics.py
@@ -1,0 +1,101 @@
+"""Diagnostics support for the WyBot integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from . import WyBotConfigEntry
+from .const import CONF_WIFI_PASSWORD, CONF_WIFI_SSID
+
+# Key used by the config flow to persist the Bluetooth address of a
+# discovered device (see config_flow.CONF_DISCOVERED_DEVICE_ADDRESS).
+CONF_DISCOVERED_DEVICE_ADDRESS = "discovered_device_address"
+
+# Secrets to strip from the config entry data.
+TO_REDACT_ENTRY = {
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_WIFI_PASSWORD,
+    CONF_WIFI_SSID,
+    CONF_DISCOVERED_DEVICE_ADDRESS,
+}
+
+# Identifying/BLE fields to strip from the coordinator summary. These match at
+# any nesting depth because async_redact_data recurses into nested mappings.
+TO_REDACT_COORDINATOR = {"ble_name", "mac"}
+
+
+def _serialize_dp(dp: Any) -> Any:
+    """Return a plain, JSON-safe representation of a DP object.
+
+    DP values are ``GenericDP`` instances (with a ``dict()`` method returning
+    ``id``/``type``/``len``/``data``). We never dump raw bytes: ``data`` is a
+    hex string. Anything unexpected falls back to ``str()`` so serialization
+    can never raise.
+    """
+    try:
+        if hasattr(dp, "dict"):
+            return dp.dict()
+    except Exception:  # noqa: BLE001 - diagnostics must never raise
+        pass
+    return str(dp)
+
+
+def _serialize_device(obj: Any, id_attr: str, type_attr: str) -> dict[str, Any]:
+    """Summarize a Device/Docker: id, type, ble name, online, and DP state."""
+    dps = getattr(obj, "dps", None) or {}
+    return {
+        "id": getattr(obj, id_attr, None),
+        "type": getattr(obj, type_attr, None),
+        "ble_name": getattr(obj, "ble_name", None),
+        "online": getattr(obj, "online", None),
+        "dps": {key: _serialize_dp(value) for key, value in dps.items()},
+    }
+
+
+def _serialize_group(group: Any) -> dict[str, Any]:
+    """Summarize a single Group (its device and optional docker)."""
+    info: dict[str, Any] = {
+        "group_id": getattr(group, "id", None),
+        "name": getattr(group, "name", None),
+        "device": None,
+        "docker": None,
+    }
+    device = getattr(group, "device", None)
+    if device is not None:
+        info["device"] = _serialize_device(device, "device_id", "device_type")
+    docker = getattr(group, "docker", None)
+    if docker is not None:
+        info["docker"] = _serialize_device(docker, "docker_id", "docker_type")
+    return info
+
+
+def _serialize_coordinator(coordinator: Any) -> dict[str, Any] | None:
+    """Summarize the coordinator state, tolerating missing data."""
+    if coordinator is None:
+        return None
+    data = getattr(coordinator, "data", None) or {}
+    return {
+        "available": bool(getattr(coordinator, "available", False)),
+        "device_count": len(data),
+        "groups": {
+            group_id: _serialize_group(group) for group_id, group in data.items()
+        },
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: WyBotConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = getattr(entry, "runtime_data", None)
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT_ENTRY),
+        "coordinator": async_redact_data(
+            _serialize_coordinator(coordinator), TO_REDACT_COORDINATOR
+        ),
+    }

--- a/custom_components/wybot/icons.json
+++ b/custom_components/wybot/icons.json
@@ -1,0 +1,27 @@
+{
+  "entity": {
+    "sensor": {
+      "dock_type": {
+        "default": "mdi:home-import-outline"
+      },
+      "last_ble_communication": {
+        "default": "mdi:bluetooth-connect"
+      },
+      "last_mqtt_communication": {
+        "default": "mdi:cloud-clock"
+      },
+      "data_source": {
+        "default": "mdi:help-circle",
+        "state": {
+          "Bluetooth": "mdi:bluetooth",
+          "Cloud (MQTT)": "mdi:cloud"
+        }
+      }
+    },
+    "button": {
+      "wifi_reconfigure": {
+        "default": "mdi:wifi-cog"
+      }
+    }
+  }
+}

--- a/custom_components/wybot/manifest.json
+++ b/custom_components/wybot/manifest.json
@@ -21,9 +21,9 @@
     "custom_components.wybot",
     "wybot"
   ],
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": [
     "pywybot==0.1.0"
   ],
-  "version": "3.1.0"
+  "version": "3.2.0"
 }

--- a/custom_components/wybot/quality_scale.yaml
+++ b/custom_components/wybot/quality_scale.yaml
@@ -60,3 +60,38 @@ rules:
   test-coverage:
     status: done
     comment: 99% coverage on the HA test harness (pytest-homeassistant-custom-component).
+
+  # --- Gold ---
+  devices: done
+  diagnostics: done
+  discovery: done
+  discovery-update-info:
+    status: done
+    comment: Bluetooth re-discovery updates the stored device address on the entry.
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: done
+    comment: Platforms create entities for devices added to the account after setup.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: >-
+      The only user-actionable failure is invalid credentials, which is handled by
+      the reauthentication flow; other failures (BLE/cloud unreachable) auto-recover.
+  stale-devices:
+    status: done
+    comment: >-
+      Devices removed from the account are purged from the registry, and manual
+      removal is allowed via async_remove_config_entry_device.

--- a/custom_components/wybot/sensor.py
+++ b/custom_components/wybot/sensor.py
@@ -49,25 +49,33 @@ async def async_setup_entry(
 ) -> None:
     """Set up the WyBot sensor platform."""
     coordinator = entry.runtime_data
+    known: set[str] = set()
 
-    entities: list[SensorEntity] = []
+    @callback
+    def _add_new_devices() -> None:
+        """Add sensor entities for devices discovered after setup."""
+        entities: list[SensorEntity] = []
+        for device_id in coordinator.vacuums:
+            if device_id in known:
+                continue
+            known.add(device_id)
+            entities.extend(
+                [
+                    WyBotRobotBatterySensor(idx=device_id, coordinator=coordinator),
+                    WyBotSolarDockBatterySensor(idx=device_id, coordinator=coordinator),
+                    WyBotSolarEnergySensor(idx=device_id, coordinator=coordinator),
+                    WyBotDockTypeSensor(idx=device_id, coordinator=coordinator),
+                    # Diagnostic sensors for communication tracking
+                    WyBotLastBLECommunicationSensor(idx=device_id, coordinator=coordinator),
+                    WyBotLastMQTTCommunicationSensor(idx=device_id, coordinator=coordinator),
+                    WyBotDataSourceSensor(idx=device_id, coordinator=coordinator),
+                ]
+            )
+        if entities:
+            async_add_entities(entities)
 
-    for device_id in coordinator.vacuums:
-        # Add sensors for each device
-        entities.extend(
-            [
-                WyBotRobotBatterySensor(idx=device_id, coordinator=coordinator),
-                WyBotSolarDockBatterySensor(idx=device_id, coordinator=coordinator),
-                WyBotSolarEnergySensor(idx=device_id, coordinator=coordinator),
-                WyBotDockTypeSensor(idx=device_id, coordinator=coordinator),
-                # Diagnostic sensors for communication tracking
-                WyBotLastBLECommunicationSensor(idx=device_id, coordinator=coordinator),
-                WyBotLastMQTTCommunicationSensor(idx=device_id, coordinator=coordinator),
-                WyBotDataSourceSensor(idx=device_id, coordinator=coordinator),
-            ]
-        )
-
-    async_add_entities(entities)
+    _add_new_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
 
 
 class WyBotSensorBase(SensorEntity, CoordinatorEntity):

--- a/custom_components/wybot/strings.json
+++ b/custom_components/wybot/strings.json
@@ -22,6 +22,14 @@
         "data": {
           "password": "Password"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure WyBot account",
+        "description": "Update the WyBot account credentials used by this integration.",
+        "data": {
+          "username": "Email",
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -34,6 +42,7 @@
       "already_configured": "Account is already configured",
       "already_in_progress": "Configuration flow is already in progress",
       "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
       "wrong_account": "The credentials are for a different WyBot account"
     }
   },
@@ -92,6 +101,17 @@
       "data_source": {
         "name": "Data source"
       }
+    }
+  },
+  "exceptions": {
+    "device_unavailable": {
+      "message": "The WyBot device is not available to receive commands."
+    },
+    "cannot_send_command": {
+      "message": "Failed to send the command to the WyBot device via Bluetooth or the cloud."
+    },
+    "wifi_send_failed": {
+      "message": "Failed to send WiFi credentials to dock {device} via Bluetooth."
     }
   }
 }

--- a/custom_components/wybot/vacuum.py
+++ b/custom_components/wybot/vacuum.py
@@ -57,12 +57,22 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the vacuum platform."""
-
     coordinator = entry.runtime_data
-    async_add_entities(
-        WyBotVacuum(idx=deviceId, coordinator=coordinator)
-        for deviceId in coordinator.vacuums
-    )
+    known: set[str] = set()
+
+    @callback
+    def _add_new_devices() -> None:
+        """Add vacuum entities for devices discovered after setup."""
+        new_ids = [d for d in coordinator.vacuums if d not in known]
+        known.update(new_ids)
+        if new_ids:
+            async_add_entities(
+                WyBotVacuum(idx=device_id, coordinator=coordinator)
+                for device_id in new_ids
+            )
+
+    _add_new_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
 
 
 class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
@@ -276,37 +286,33 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity):
             | VacuumEntityFeature.STOP
         )
 
-    async def _async_send_command(self, dp: GenericDP, action: str) -> None:
+    async def _async_send_command(self, dp: GenericDP) -> None:
         """Send a command to the device, raising on failure."""
         if not self._data:
             raise HomeAssistantError(
-                f"Cannot {action}: WyBot device is not available"
+                translation_domain=DOMAIN, translation_key="device_unavailable"
             )
         if not await self.coordinator.async_send_command(self._data, dp):
             raise HomeAssistantError(
-                f"Failed to {action} via BLE or MQTT"
+                translation_domain=DOMAIN, translation_key="cannot_send_command"
             )
 
     async def async_set_fan_speed(self, fan_speed: str) -> None:
         """Set the fan speed of the vacuum cleaner."""
-        await self._async_send_command(
-            CleaningMode(mode=fan_speed), "set the cleaning mode"
-        )
+        await self._async_send_command(CleaningMode(mode=fan_speed))
 
     async def async_stop(self) -> None:
         """Stop the vacuum cleaner."""
         await self._async_send_command(
-            CleaningStatus(status=CleaningStatusMode.STOPPED), "stop the cleaner"
+            CleaningStatus(status=CleaningStatusMode.STOPPED)
         )
 
     async def async_start(self) -> None:
         """Start the vacuum cleaner."""
         await self._async_send_command(
-            CleaningStatus(status=CleaningStatusMode.CLEANING), "start the cleaner"
+            CleaningStatus(status=CleaningStatusMode.CLEANING)
         )
 
     async def async_return_to_base(self) -> None:
         """Return the vacuum cleaner to the dock."""
-        await self._async_send_command(
-            Dock(status=DockStatus.RETURNING), "return the cleaner to base"
-        )
+        await self._async_send_command(Dock(status=DockStatus.RETURNING))

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -313,3 +313,124 @@ async def test_bluetooth_discovery_robot_name(hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+
+
+async def _start_reconfigure(hass: HomeAssistant, entry: MockConfigEntry):
+    """Start a reconfigure flow, preferring the helper when available."""
+    if hasattr(entry, "start_reconfigure_flow"):
+        return await entry.start_reconfigure_flow(hass)
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+
+async def test_reconfigure_success(hass: HomeAssistant) -> None:
+    """Reconfigure updates the stored username/password and reloads the entry."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_user = "new@example.com"
+    with _patch_client(_client(user_id=USER_ID)), _patch_setup():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: new_user, CONF_PASSWORD: "newpass"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_USERNAME] == new_user
+    assert entry.data[CONF_PASSWORD] == "newpass"
+
+
+async def test_reconfigure_wrong_account(hass: HomeAssistant) -> None:
+    """Reconfiguring to a different account is rejected."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    with _patch_client(_client(user_id="different-account")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "other@example.com", CONF_PASSWORD: "newpass"},
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
+async def test_reconfigure_invalid_auth(hass: HomeAssistant) -> None:
+    """Bad credentials during reconfigure show an error and stay on the form."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    with _patch_client(_client(authenticate=WybotAuthError)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USER, CONF_PASSWORD: "bad"},
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected"),
+    [
+        (WybotConnectionError, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_reconfigure_errors(
+    hass: HomeAssistant, side_effect, expected
+) -> None:
+    """Connection and unexpected errors during reconfigure show a form error."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    with _patch_client(_client(authenticate=side_effect)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USER, CONF_PASSWORD: "bad"},
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected}
+
+
+async def test_bluetooth_discovery_updates_configured_entry(
+    hass: HomeAssistant,
+) -> None:
+    """A discovery for an already-configured dock updates its stored address."""
+    address = "AA:BB:CC:DD:EE:FF"
+    from homeassistant.helpers.device_registry import format_mac
+
+    entry = _entry(
+        unique_id=format_mac(address),
+        **{
+            "discovered_device_address": "00:00:00:00:00:00",
+            "discovered_device_name": "DS20-OLD",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    info = _service_info(name="DS20-NEW", address=address)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=info,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    # The stored discovered device info was refreshed from the new advertisement.
+    assert entry.data["discovered_device_address"] == address
+    assert entry.data["discovered_device_name"] == "DS20-NEW"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,232 @@
+"""Tests for the WyBot diagnostics module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.wybot.const import (
+    CONF_WIFI_PASSWORD,
+    CONF_WIFI_SSID,
+    DOMAIN,
+)
+from custom_components.wybot.diagnostics import (
+    CONF_DISCOVERED_DEVICE_ADDRESS,
+    _serialize_coordinator,
+    _serialize_dp,
+    async_get_config_entry_diagnostics,
+)
+from custom_components.wybot.wybot_coordinator import WyBotCoordinator
+from wybot.dp_models import DP, CleaningStatus
+from wybot.models import Group
+
+DEVICE_ID = "dev123"
+DOCKER_ID = "dock456"
+GROUP_ID = "group1"
+DEVICE_BLE = "CCBA97932A96"
+DOCKER_BLE = "3C8427565A1A"
+
+PASSWORD = "supersecret"
+WIFI_PASSWORD = "wifisecret"
+DISCOVERED_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+def _group_data(with_docker: bool = True) -> dict:
+    data = {
+        "device": {
+            "deviceId": DEVICE_ID,
+            "deviceName": "Pool Robot",
+            "deviceType": "S2 Pro",
+            "bleName": DEVICE_BLE,
+            "autoUpdate": "1",
+            "version": {"Firmware": "1.2.3"},
+        },
+        "docker": {
+            "dockerId": DOCKER_ID,
+            "dockerType": "DS20",
+            "bleName": DOCKER_BLE,
+            "deviceStatus": "online",
+            "dockerStatus": "active",
+            "schedule": None,
+            "version": {"Firmware": "2.0.0"},
+        },
+        "vision": {
+            "visionId": "vis789",
+            "privacy": False,
+            "log": None,
+            "video": None,
+            "picture": None,
+            "policy": True,
+        },
+        "name": "My Pool",
+        "id": GROUP_ID,
+        "autoUpdate": "1",
+    }
+    if not with_docker:
+        data["docker"] = None
+    return data
+
+
+def make_group(with_docker: bool = True) -> Group:
+    """Build a Group with a cleaning-status DP populated on the device."""
+    group = Group(**_group_data(with_docker=with_docker))
+    group.device.dps = {"0": CleaningStatus(DP(id=0, type=4, len=1, data="03"))}
+    return group
+
+
+def make_coordinator(hass: HomeAssistant, entry: MockConfigEntry) -> WyBotCoordinator:
+    """Build a real coordinator with external clients mocked out."""
+    coord = WyBotCoordinator(hass, MagicMock(), entry)
+    coord.wybot_http_client = MagicMock()
+    coord.wybot_ble_client = MagicMock()
+    coord.wybot_mqtt_client = MagicMock()
+    coord._connection_available = True
+    return coord
+
+
+def make_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="acct",
+        data={
+            CONF_USERNAME: "user@example.com",
+            CONF_PASSWORD: PASSWORD,
+            CONF_WIFI_SSID: "HomeNet",
+            CONF_WIFI_PASSWORD: WIFI_PASSWORD,
+            CONF_DISCOVERED_DEVICE_ADDRESS: DISCOVERED_ADDRESS,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# async_get_config_entry_diagnostics
+# ---------------------------------------------------------------------------
+
+
+async def test_diagnostics_redacts_secrets(hass: HomeAssistant) -> None:
+    entry = make_entry(hass)
+    coord = make_coordinator(hass, entry)
+    coord.data = {GROUP_ID: make_group()}
+    entry.runtime_data = coord
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    entry_data = result["entry_data"]
+    # Secrets are redacted, not present verbatim.
+    assert entry_data[CONF_PASSWORD] != PASSWORD
+    assert entry_data[CONF_WIFI_PASSWORD] != WIFI_PASSWORD
+    assert entry_data[CONF_USERNAME] != "user@example.com"
+    assert entry_data[CONF_DISCOVERED_DEVICE_ADDRESS] != DISCOVERED_ADDRESS
+
+    # No secret leaks anywhere in the serialized output.
+    dumped = str(result)
+    assert PASSWORD not in dumped
+    assert WIFI_PASSWORD not in dumped
+    assert DISCOVERED_ADDRESS not in dumped
+    # BLE names/MACs are redacted too.
+    assert DEVICE_BLE not in dumped
+    assert DOCKER_BLE not in dumped
+
+
+async def test_diagnostics_includes_device_and_dp_info(hass: HomeAssistant) -> None:
+    entry = make_entry(hass)
+    coord = make_coordinator(hass, entry)
+    coord.data = {GROUP_ID: make_group()}
+    entry.runtime_data = coord
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    coordinator = result["coordinator"]
+    assert coordinator["available"] is True
+    assert coordinator["device_count"] == 1
+
+    group = coordinator["groups"][GROUP_ID]
+    assert group["group_id"] == GROUP_ID
+    assert group["name"] == "My Pool"
+
+    device = group["device"]
+    assert device["id"] == DEVICE_ID
+    assert device["type"] == "S2 Pro"
+    assert device["ble_name"] == "**REDACTED**"
+    # The cleaning-status DP is serialized to a plain dict, no raw objects.
+    assert device["dps"]["0"] == {"id": 0, "type": 4, "len": 1, "data": "03"}
+
+    docker = group["docker"]
+    assert docker["id"] == DOCKER_ID
+    assert docker["type"] == "DS20"
+    assert docker["dps"] == {}
+
+
+async def test_diagnostics_group_without_docker(hass: HomeAssistant) -> None:
+    entry = make_entry(hass)
+    coord = make_coordinator(hass, entry)
+    coord.data = {GROUP_ID: make_group(with_docker=False)}
+    entry.runtime_data = coord
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    group = result["coordinator"]["groups"][GROUP_ID]
+    assert group["docker"] is None
+    assert group["device"]["id"] == DEVICE_ID
+
+
+async def test_diagnostics_missing_runtime_data(hass: HomeAssistant) -> None:
+    """Diagnostics must not raise when the coordinator is absent."""
+    entry = make_entry(hass)
+    # No runtime_data attached.
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["coordinator"] is None
+    # Entry data is still redacted.
+    assert result["entry_data"][CONF_PASSWORD] != PASSWORD
+
+
+async def test_diagnostics_empty_coordinator_data(hass: HomeAssistant) -> None:
+    entry = make_entry(hass)
+    coord = make_coordinator(hass, entry)
+    coord._connection_available = False
+    coord.data = {}
+    entry.runtime_data = coord
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    coordinator = result["coordinator"]
+    assert coordinator["available"] is False
+    assert coordinator["device_count"] == 0
+    assert coordinator["groups"] == {}
+
+
+# ---------------------------------------------------------------------------
+# helper unit tests (robust serialization branches)
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_dp_plain_object() -> None:
+    dp = CleaningStatus(DP(id=0, type=4, len=1, data="03"))
+    assert _serialize_dp(dp) == {"id": 0, "type": 4, "len": 1, "data": "03"}
+
+
+def test_serialize_dp_without_dict_method() -> None:
+    # An object with no dict() falls back to str() and never raises.
+    assert _serialize_dp("raw") == "raw"
+
+
+def test_serialize_dp_dict_raises() -> None:
+    class Boom:
+        def dict(self):  # noqa: D401 - test double
+            raise ValueError("boom")
+
+        def __str__(self) -> str:
+            return "boom-str"
+
+    assert _serialize_dp(Boom()) == "boom-str"
+
+
+def test_serialize_coordinator_none() -> None:
+    assert _serialize_coordinator(None) is None

--- a/tests/test_dynamic_devices.py
+++ b/tests/test_dynamic_devices.py
@@ -1,0 +1,57 @@
+"""Tests for dynamic device addition (devices added after setup)."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.wybot.binary_sensor import async_setup_entry as bs_setup
+from custom_components.wybot.button import async_setup_entry as btn_setup
+from custom_components.wybot.sensor import async_setup_entry as sensor_setup
+from custom_components.wybot.vacuum import async_setup_entry as vacuum_setup
+from wybot_platform_helpers import make_coordinator, make_group
+
+
+def _capture():
+    """Return (list, callback) that collects entities passed to async_add_entities."""
+    added: list = []
+
+    def cb(new_entities, update_before_add=False):
+        added.extend(list(new_entities))
+
+    return added, cb
+
+
+async def _assert_dynamic(hass, setup, wifi=False):
+    kwargs = {"wifi_ssid": "net", "wifi_password": "pw"} if wifi else {}
+    coord, entry = make_coordinator(hass, {"g1": make_group()}, **kwargs)
+    entry.runtime_data = coord
+    added, cb = _capture()
+
+    await setup(hass, entry, cb)
+    first = len(added)
+    assert first > 0
+
+    # Re-firing with the same devices hits the "already known" branch — no dupes.
+    coord.async_update_listeners()
+    assert len(added) == first
+
+    # A new device appearing creates entities dynamically.
+    coord.data = {"g1": make_group(), "g2": make_group(name="Pool 2")}
+    coord.async_update_listeners()
+    assert len(added) > first
+
+
+async def test_sensor_dynamic_devices(hass: HomeAssistant) -> None:
+    await _assert_dynamic(hass, sensor_setup)
+
+
+async def test_binary_sensor_dynamic_devices(hass: HomeAssistant) -> None:
+    await _assert_dynamic(hass, bs_setup)
+
+
+async def test_vacuum_dynamic_devices(hass: HomeAssistant) -> None:
+    await _assert_dynamic(hass, vacuum_setup)
+
+
+async def test_button_dynamic_devices(hass: HomeAssistant) -> None:
+    await _assert_dynamic(hass, btn_setup, wifi=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,13 +7,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.wybot import (
+    _async_purge_stale_devices,
+    _device_identifiers,
+    async_remove_config_entry_device,
+)
 from custom_components.wybot.const import DOMAIN
 from wybot import (
     WybotAuthError,
     WybotConnectionError,
 )
+from wybot_platform_helpers import make_coordinator, make_group
 
 USER = "pool@example.com"
 PASSWORD = "hunter2"
@@ -120,3 +127,52 @@ async def test_update_listener_refreshes_wifi_credentials(hass: HomeAssistant) -
     await _async_update_listener(hass, entry)
 
     coordinator.set_wifi_credentials.assert_called_once_with("net", "pw")
+
+
+def test_device_identifiers(hass: HomeAssistant) -> None:
+    """Device identifiers include the robot and (when present) the dock."""
+    coordinator, _ = make_coordinator(hass, {"grp1": make_group()})
+    ids = _device_identifiers(coordinator)
+    assert (DOMAIN, "grp1") in ids
+    assert (DOMAIN, "grp1_dock") in ids
+
+    no_dock, _ = make_coordinator(hass, {"g2": make_group(with_docker=False)})
+    ids2 = _device_identifiers(no_dock)
+    assert (DOMAIN, "g2") in ids2
+    assert (DOMAIN, "g2_dock") not in ids2
+
+
+async def test_purge_stale_devices(hass: HomeAssistant) -> None:
+    """Devices no longer on the account are unlinked from the entry."""
+    coordinator, entry = make_coordinator(hass, {"grp1": make_group()})
+    entry.runtime_data = coordinator
+    registry = dr.async_get(hass)
+    current = registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "grp1")}
+    )
+    stale = registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "old_robot")}
+    )
+
+    _async_purge_stale_devices(hass, entry, coordinator)
+    await hass.async_block_till_done()
+
+    assert registry.async_get(current.id) is not None
+    stale_after = registry.async_get(stale.id)
+    assert stale_after is None or entry.entry_id not in stale_after.config_entries
+
+
+async def test_async_remove_config_entry_device(hass: HomeAssistant) -> None:
+    """Manual device removal is allowed only for devices not on the account."""
+    coordinator, entry = make_coordinator(hass, {"grp1": make_group()})
+    entry.runtime_data = coordinator
+    registry = dr.async_get(hass)
+    present = registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "grp1")}
+    )
+    absent = registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "gone")}
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, present) is False
+    assert await async_remove_config_entry_device(hass, entry, absent) is True


### PR DESCRIPTION
Implements the remaining Home Assistant **Gold** quality-scale rules on top of Silver (v3.1.0).

## New capabilities
- **diagnostics** — downloadable, redacted config + device/DP state (`diagnostics.py`).
- **reconfiguration-flow** — change account credentials without removing the integration.
- **discovery-update-info** — Bluetooth re-discovery refreshes the stored device address.
- **dynamic-devices** — entities are created for devices added to the account after setup (all platforms use a coordinator listener).
- **stale-devices** — devices removed from the account are purged from the registry; manual removal via `async_remove_config_entry_device`.
- **icon-translations** — `icons.json` (state-based icons for the data-source sensor, etc.).
- **exception-translations** — vacuum/button errors use translatable `exceptions` keys.
- **docs** — use-cases, example automations, known-limitations, troubleshooting.

`repair-issues` is marked **exempt** (the only user-actionable failure — invalid credentials — is handled by the reauth flow; other failures auto-recover).

## Quality
- All 51 Bronze+Silver+Gold rules are **done (46)** or **exempt (5)** — zero todo.
- Manifest declares `quality_scale: gold`.
- **205 tests, 99% coverage** (every module 100% except the coordinator's provably-unreachable retry tail). CI gated at 95%.
- Version bump to 3.2.0.