### PR TITLE
Add F1 pool skimmer support (closes #12)

### DIFF
--- a/custom_components/wybot/__init__.py
+++ b/custom_components/wybot/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.SENSOR,
+    Platform.SWITCH,
     Platform.VACUUM,
 ]
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/wybot/binary_sensor.py
+++ b/custom_components/wybot/binary_sensor.py
@@ -56,6 +56,7 @@ async def async_setup_entry(
                 [
                     WyBotRobotChargingBinarySensor(idx=device_id, coordinator=coordinator),
                     WyBotDockChargingBinarySensor(idx=device_id, coordinator=coordinator),
+                    WyBotFullyChargedBinarySensor(idx=device_id, coordinator=coordinator),
                 ]
             )
         if entities:
@@ -234,10 +235,16 @@ class WyBotDockChargingBinarySensor(WyBotDockBinarySensorBase):
         """Return True if the dock is charging (solar)."""
         if not self._data:
             return None
+        # DS20 dock: uses DP 222 (SolarStatus)
         solar_status = self._data.get_dp(SolarStatus)
-        if solar_status is None:
-            return None
-        return solar_status.is_charging
+        if solar_status is not None:
+            return solar_status.is_charging
+        # F1 fallback: DP 50 charge_state == CHARGING means solar is active
+        from wybot.dp_models import BatteryState
+        battery = self._data.get_dp(Battery)
+        if battery is not None:
+            return battery.charge_state == BatteryState.CHARGING
+        return None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -254,3 +261,46 @@ class WyBotDockChargingBinarySensor(WyBotDockBinarySensorBase):
             if solar_status is not None:
                 attrs["raw_value"] = solar_status.data
         return attrs
+
+
+class WyBotFullyChargedBinarySensor(WyBotBinarySensorBase):
+    """Binary sensor for fully charged status.
+
+    Tracks charge_state from DP 50:
+    - 0 (NOT_PLUGGED_IN) = off
+    - 1 (CHARGING) = off
+    - 2 (CHARGED) = on
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    _attr_translation_key = "fully_charged"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_fully_charged"
+
+    @property
+    def name(self) -> str:
+        return "Fully charged"
+
+    @property
+    def is_on(self) -> bool | None:
+        if not self._data:
+            return None
+        battery = self._data.get_dp(Battery)
+        if battery is None:
+            return None
+        return battery.charge_state == BatteryState.CHARGED
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        attrs = {}
+        if self._data:
+            battery = self._data.get_dp(Battery)
+            if battery is not None:
+                attrs["charge_state"] = battery.charge_state.name
+                if battery.data and len(battery.data) >= 6:
+                    attrs["solar_battery"] = int(battery.data[2:4], 16)
+                    attrs["robot_battery"] = battery.battery_level
+        return attrs
+

--- a/custom_components/wybot/binary_sensor.py
+++ b/custom_components/wybot/binary_sensor.py
@@ -301,6 +301,6 @@ class WyBotFullyChargedBinarySensor(WyBotBinarySensorBase):
                 attrs["charge_state"] = battery.charge_state.name
                 if battery.data and len(battery.data) >= 6:
                     attrs["solar_battery"] = int(battery.data[2:4], 16)
-                    attrs["robot_battery"] = battery.battery_level
+                    attrs["robot_battery"] = battery.robot_battery_level
         return attrs
 

--- a/custom_components/wybot/binary_sensor.py
+++ b/custom_components/wybot/binary_sensor.py
@@ -240,7 +240,6 @@ class WyBotDockChargingBinarySensor(WyBotDockBinarySensorBase):
         if solar_status is not None:
             return solar_status.is_charging
         # F1 fallback: DP 50 charge_state == CHARGING means solar is active
-        from wybot.dp_models import BatteryState
         battery = self._data.get_dp(Battery)
         if battery is not None:
             return battery.charge_state == BatteryState.CHARGING
@@ -272,19 +271,23 @@ class WyBotFullyChargedBinarySensor(WyBotBinarySensorBase):
     - 2 (CHARGED) = on
     """
 
-    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    # Deliberately no device class: BATTERY_CHARGING would render this as
+    # "Charging"/"Not charging", which is the opposite of what it reports.
     _attr_translation_key = "fully_charged"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_fully_charged"
 
     @property
     def name(self) -> str:
+        """Return the name of the binary sensor."""
         return "Fully charged"
 
     @property
     def is_on(self) -> bool | None:
+        """Return True when the battery reports a completed charge."""
         if not self._data:
             return None
         battery = self._data.get_dp(Battery)
@@ -293,14 +296,16 @@ class WyBotFullyChargedBinarySensor(WyBotBinarySensorBase):
         return battery.charge_state == BatteryState.CHARGED
 
     @property
-    def extra_state_attributes(self) -> dict:
-        attrs = {}
-        if self._data:
-            battery = self._data.get_dp(Battery)
-            if battery is not None:
-                attrs["charge_state"] = battery.charge_state.name
-                if battery.data and len(battery.data) >= 6:
-                    attrs["solar_battery"] = int(battery.data[2:4], 16)
-                    attrs["robot_battery"] = battery.robot_battery_level
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes."""
+        if not self._data:
+            return {}
+        battery = self._data.get_dp(Battery)
+        if battery is None:
+            return {}
+        attrs: dict[str, Any] = {"charge_state": battery.charge_state.name}
+        solar_battery = battery.solar_battery_level
+        if solar_battery is not None:
+            attrs["solar_battery"] = solar_battery
         return attrs
 

--- a/custom_components/wybot/const.py
+++ b/custom_components/wybot/const.py
@@ -3,6 +3,11 @@
 DOMAIN = "wybot"
 MANUFACTURER = "WyBot"
 
+# The F1 skimmer reports this device type. It has no dock (the solar panel is
+# integrated), exposes sensors the DS20 robots do not, and encodes several DPs
+# differently, so a number of entities are only created for it.
+F1_DEVICE_TYPE = "WYF1"
+
 # WiFi configuration constants (for manual WiFi provisioning via diagnostic button)
 CONF_WIFI_SSID = "wifi_ssid"
 CONF_WIFI_PASSWORD = "wifi_password"

--- a/custom_components/wybot/icons.json
+++ b/custom_components/wybot/icons.json
@@ -16,11 +16,43 @@
           "Bluetooth": "mdi:bluetooth",
           "Cloud (MQTT)": "mdi:cloud"
         }
+      },
+      "working_time": {
+        "default": "mdi:timer-outline"
+      },
+      "cleaning_mode": {
+        "default": "mdi:broom"
+      },
+      "total_runtime": {
+        "default": "mdi:timer-sand"
+      },
+      "cycle_runtime": {
+        "default": "mdi:timer-play-outline"
+      },
+      "motor_pwm": {
+        "default": "mdi:engine-outline"
+      },
+      "heavy_dirt": {
+        "default": "mdi:liquid-spot"
+      },
+      "in_water": {
+        "default": "mdi:waves"
+      },
+      "sonar": {
+        "default": "mdi:radar"
+      },
+      "ph_value": {
+        "default": "mdi:ph"
       }
     },
     "button": {
       "wifi_reconfigure": {
         "default": "mdi:wifi-cog"
+      }
+    },
+    "switch": {
+      "auto_run": {
+        "default": "mdi:robot-outline"
       }
     }
   }

--- a/custom_components/wybot/manifest.json
+++ b/custom_components/wybot/manifest.json
@@ -23,7 +23,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "pywybot==1.0.0"
+    "pywybot==1.3.0"
   ],
   "version": "3.3.0"
 }

--- a/custom_components/wybot/sensor.py
+++ b/custom_components/wybot/sensor.py
@@ -7,12 +7,19 @@ import logging
 from typing import Any, cast
 
 from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfEnergy
+from homeassistant.const import (
+    EntityCategory,
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -20,15 +27,15 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import WyBotConfigEntry
 from .const import DOMAIN, MANUFACTURER
 from .wybot_coordinator import WyBotCoordinator
-import json as json_module
 
 from wybot.dp_models import (
     Battery,
     CleaningMode,
     DockInfo,
-    GenericDP,
+    HeavyDirtMode,
+    PhData,
     SolarDockBattery,
-    SolarEnergyHarvested,
+    WorkingTime,
 )
 from wybot.models import Group
 
@@ -56,6 +63,17 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
     known: set[str] = set()
 
+    # DP 131 was previously exposed as an energy sensor in Wh. It is really
+    # working time in seconds, so the old entity is retired rather than
+    # silently changing units under existing statistics.
+    entity_registry = er.async_get(hass)
+    for device_id in coordinator.vacuums:
+        old_entity_id = entity_registry.async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, f"wybot_{device_id}_solar_energy"
+        )
+        if old_entity_id is not None:
+            entity_registry.async_remove(old_entity_id)
+
     @callback
     def _add_new_devices() -> None:
         """Add sensor entities for devices discovered after setup."""
@@ -68,29 +86,29 @@ async def async_setup_entry(
                 [
                     WyBotRobotBatterySensor(idx=device_id, coordinator=coordinator),
                     WyBotSolarDockBatterySensor(idx=device_id, coordinator=coordinator),
-                    WyBotSolarEnergySensor(idx=device_id, coordinator=coordinator),
+                    WyBotWorkingTimeSensor(idx=device_id, coordinator=coordinator),
                     WyBotDockTypeSensor(idx=device_id, coordinator=coordinator),
-                    # F1-specific: integrated solar battery (reads DP 50 middle byte)
-                    WyBotF1SolarBatterySensor(idx=device_id, coordinator=coordinator),
-                    # F1-specific: runtime, temperature, energy sensors
-                    WyBotF1RuntimeSensor(idx=device_id, coordinator=coordinator),
-                    WyBotF1CycleRuntimeSensor(idx=device_id, coordinator=coordinator),
-                    WyBotF1WaterTempSensor(idx=device_id, coordinator=coordinator),
-                    WyBotF1TotalEnergySensor(idx=device_id, coordinator=coordinator),
-                    WyBotF1MotorPWMSensor(idx=device_id, coordinator=coordinator),
-                    # F1 cleaning mode sensor
-                    WyBotF1CleaningModeSensor(idx=device_id, coordinator=coordinator),
-                    # APK-confirmed DP sensors
-                    WyBotF1HeavyDirtSensor(idx=device_id, coordinator=coordinator),
-                    WyBotF1InWaterSensor(idx=device_id, coordinator=coordinator),
-                    WyBotF1SonarSensor(idx=device_id, coordinator=coordinator),
-                    WyBotF1PhSensor(idx=device_id, coordinator=coordinator),
                     # Diagnostic sensors for communication tracking
                     WyBotLastBLECommunicationSensor(idx=device_id, coordinator=coordinator),
                     WyBotLastMQTTCommunicationSensor(idx=device_id, coordinator=coordinator),
                     WyBotDataSourceSensor(idx=device_id, coordinator=coordinator),
                 ]
             )
+            if coordinator.is_f1(device_id):
+                entities.extend(
+                    [
+                        WyBotF1SolarBatterySensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1CleaningModeSensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1RuntimeSensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1CycleRuntimeSensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1TotalEnergySensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1MotorPWMSensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1HeavyDirtSensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1InWaterSensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1SonarSensor(idx=device_id, coordinator=coordinator),
+                        WyBotF1PhSensor(idx=device_id, coordinator=coordinator),
+                    ]
+                )
         if entities:
             async_add_entities(entities)
 
@@ -205,6 +223,22 @@ class WyBotDockSensorBase(WyBotSensorBase):
         # compatibility); cast the loosely-typed kwargs.
         return cast(DeviceInfo, info_kwargs)
 
+    def _comm_device_id(self) -> str | None:
+        """Return the id the coordinator tracks BLE/MQTT traffic under.
+
+        On a DS20 the dock is the transport endpoint, so traffic is recorded
+        under the dock id. The F1 has no dock but still reports a placeholder
+        docker entry with an empty id, so an empty id falls through to the
+        robot rather than being used as-is.
+        """
+        if not self._data:
+            return None
+        if self._data.docker and self._data.docker.docker_id:
+            return self._data.docker.docker_id
+        if self._data.device and self._data.device.device_id:
+            return self._data.device.device_id
+        return None
+
 
 class WyBotRobotBatterySensor(WyBotSensorBase):
     """Sensor for robot battery level."""
@@ -278,23 +312,26 @@ class WyBotSolarDockBatterySensor(WyBotDockSensorBase):
         return None
 
 
-class WyBotSolarEnergySensor(WyBotDockSensorBase):
+class WyBotWorkingTimeSensor(WyBotDockSensorBase):
     """Sensor for total working time (DP 131).
 
-    Previously labeled 'Energy harvested' — APK analysis revealed DP 131 (0x83)
-    is actually 'working time' in seconds, not energy in Wh.
-    Kept the class name for entity ID stability but changed unit to seconds.
+    This DP was previously exposed as "Energy harvested" in Wh. Decompiling the
+    vendor app showed DP 131 (0x83) is working time in seconds and was never an
+    energy reading, so this is a distinct entity rather than a unit change on
+    the old one — the recorder cannot migrate Wh statistics to seconds, and the
+    old series was meaningless anyway. The obsolete entity is removed from the
+    registry in async_setup_entry.
     """
 
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = "s"
-    _attr_translation_key = "solar_energy"
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_translation_key = "working_time"
 
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return f"wybot_{self._idx}_solar_energy"
+        return f"wybot_{self._idx}_working_time"
 
     @property
     def name(self) -> str:
@@ -306,22 +343,10 @@ class WyBotSolarEnergySensor(WyBotDockSensorBase):
         """Return the total working time in seconds."""
         if not self._data:
             return None
-        # DP 131 (0x83) = working time (confirmed by APK, was SolarEnergyHarvested)
-        working_time = self._data.get_dp(SolarEnergyHarvested)
-        if working_time is not None:
-            # Use the old class's energy_wh property which actually reads LE 4-byte value
-            return working_time.energy_wh  # This is actually seconds, not Wh
-        # F1 fallback: DP 18 (type=2, 4-byte LE) from dock MQTT
-        if self._data and self._data.docker:
-            dp18 = self._data.docker.dps.get("18")
-            if dp18 and dp18.data:
-                try:
-                    raw = bytes.fromhex(dp18.data)
-                    if len(raw) >= 4:
-                        return int.from_bytes(raw[:4], byteorder="little")
-                except (ValueError, IndexError):
-                    pass
-        return None
+        working_time = self._data.get_dp(WorkingTime)
+        if working_time is None:
+            return None
+        return working_time.seconds
 
 
 class WyBotDockTypeSensor(WyBotDockSensorBase):
@@ -386,13 +411,8 @@ class WyBotLastBLECommunicationSensor(WyBotDockSensorBase):
     @property
     def native_value(self) -> datetime | None:
         """Return the last BLE communication time."""
-        # Get the device ID for BLE tracking
-        # Prefer device ID since coordinator stores BLE status under device, not docker
-        if self._data and self._data.device and self._data.device.device_id:
-            device_id = self._data.device.device_id
-        elif self._data and self._data.docker and self._data.docker.docker_id:
-            device_id = self._data.docker.docker_id
-        else:
+        device_id = self._comm_device_id()
+        if device_id is None:
             return None
         return self._coordinator.get_last_ble_communication(device_id)
 
@@ -400,8 +420,8 @@ class WyBotLastBLECommunicationSensor(WyBotDockSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         attrs: dict[str, Any] = {}
-        if self._data and self._data.device and self._data.device.device_id:
-            device_id = self._data.device.device_id
+        device_id = self._comm_device_id()
+        if device_id is not None:
             attrs["ble_available"] = self._coordinator.is_ble_available(device_id)
         if self._data and self._data.docker and self._data.docker.ble_name:
             attrs["ble_name"] = self._data.docker.ble_name
@@ -429,21 +449,15 @@ class WyBotLastMQTTCommunicationSensor(WyBotDockSensorBase):
     @property
     def native_value(self) -> datetime | None:
         """Return the last MQTT communication time."""
-        # Get the device ID for MQTT tracking
-        if self._data and self._data.device and self._data.device.device_id:
-            device_id = self._data.device.device_id
-        elif self._data and self._data.docker and self._data.docker.docker_id:
-            device_id = self._data.docker.docker_id
-        else:
+        device_id = self._comm_device_id()
+        if device_id is None:
             return None
         return self._coordinator.get_last_mqtt_communication(device_id)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
-        attrs: dict[str, Any] = {}
-        attrs["mqtt_connected"] = self._coordinator._mqtt_connected
-        return attrs
+        return {"mqtt_connected": self._coordinator._mqtt_connected}
 
 
 class WyBotDataSourceSensor(WyBotDockSensorBase):
@@ -467,11 +481,8 @@ class WyBotDataSourceSensor(WyBotDockSensorBase):
     @property
     def native_value(self) -> str | None:
         """Return the current data source."""
-        if self._data and self._data.device and self._data.device.device_id:
-            device_id = self._data.device.device_id
-        elif self._data and self._data.docker and self._data.docker.docker_id:
-            device_id = self._data.docker.docker_id
-        else:
+        device_id = self._comm_device_id()
+        if device_id is None:
             return None
         source = self._coordinator.get_data_source(device_id)
         if source == "ble":
@@ -483,11 +494,8 @@ class WyBotDataSourceSensor(WyBotDockSensorBase):
     @property
     def icon(self) -> str:
         """Return the icon based on data source."""
-        if self._data and self._data.device and self._data.device.device_id:
-            device_id = self._data.device.device_id
-        elif self._data and self._data.docker and self._data.docker.docker_id:
-            device_id = self._data.docker.docker_id
-        else:
+        device_id = self._comm_device_id()
+        if device_id is None:
             return "mdi:help-circle"
         source = self._coordinator.get_data_source(device_id)
         if source == "ble":
@@ -500,11 +508,8 @@ class WyBotDataSourceSensor(WyBotDockSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         attrs: dict[str, Any] = {}
-        if self._data and self._data.device and self._data.device.device_id:
-            device_id = self._data.device.device_id
-        elif self._data and self._data.docker and self._data.docker.docker_id:
-            device_id = self._data.docker.docker_id
-        else:
+        device_id = self._comm_device_id()
+        if device_id is None:
             return attrs
         attrs["ble_available"] = self._coordinator.is_ble_available(device_id)
         attrs["mqtt_connected"] = self._coordinator._mqtt_connected
@@ -552,28 +557,19 @@ class WyBotF1SolarBatterySensor(WyBotSensorBase):
         if not self._data:
             return None
         battery = self._data.get_dp(Battery)
-        if battery is None or not battery.data:
+        if battery is None:
             return None
-        # F1 sends 3 bytes for DP 50: [charge_state][solar_battery%][robot_battery%]
-        # Standard DS20 sends 2 bytes, so only parse middle byte if 3+ bytes present
-        if len(battery.data) >= 6:  # 3 bytes = 6 hex chars
-            try:
-                return int(battery.data[2:4], 16)
-            except (ValueError, IndexError):
-                pass
-        return None
+        return battery.solar_battery_level
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
-        attrs: dict[str, Any] = {}
-        if self._data:
-            battery = self._data.get_dp(Battery)
-            if battery is not None:
-                attrs["raw_data"] = battery.data
-                attrs["charge_state"] = battery.charge_state.name
-                attrs["robot_battery"] = battery.robot_battery_level
-        return attrs
+        if not self._data:
+            return {}
+        battery = self._data.get_dp(Battery)
+        if battery is None:
+            return {}
+        return {"charge_state": battery.charge_state.name}
 
 
 # =============================================================================
@@ -581,151 +577,110 @@ class WyBotF1SolarBatterySensor(WyBotSensorBase):
 # =============================================================================
 
 
-def _get_dp_le_value(group, dp_id: str, default: int = 0) -> int:
-    """Get a DP value as little-endian integer from either device or docker."""
-    if not group:
-        return default
-    # Check device DPs first
-    dp = group.device.dps.get(str(dp_id)) if group.device else None
-    if dp is None and group.docker:
-        dp = group.docker.dps.get(str(dp_id))
-    if dp is None or not dp.data:
-        return default
-    try:
-        raw = bytes.fromhex(dp.data)
-        if len(raw) >= 4:
-            return int.from_bytes(raw[:4], byteorder="little")
-        return int.from_bytes(raw, byteorder="little")
-    except (ValueError, IndexError):
-        return default
-
-
-def _get_dp_raw(group, dp_id: str) -> str | None:
-    """Get raw DP data hex string from device or docker."""
-    if not group:
+def _get_dp_raw(group: Group | None, dp_id: str) -> str | None:
+    """Return a DP's raw hex payload, preferring the robot over the dock."""
+    if group is None:
         return None
-    dp = group.device.dps.get(str(dp_id)) if group.device else None
+    dp = group.device.dps.get(dp_id) if group.device else None
     if dp is None and group.docker:
-        dp = group.docker.dps.get(str(dp_id))
+        dp = group.docker.dps.get(dp_id)
     if dp is None or not dp.data:
         return None
     return dp.data
 
 
-class WyBotF1RuntimeSensor(WyBotSensorBase):
-    """Sensor for F1 total runtime in seconds (DP 25 / DP 111)."""
+def _get_dp_le_value(group: Group | None, dp_id: str, default: int = 0) -> int:
+    """Return a DP payload decoded as a little-endian integer.
 
-    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
-    _attr_device_class = SensorDeviceClass.DURATION
+    Several F1 DPs are not modelled in pywybot yet, so they are read by raw id
+    here. Payloads longer than four bytes are truncated to the first word.
+    """
+    data = _get_dp_raw(group, dp_id)
+    if data is None:
+        return default
+    try:
+        raw = bytes.fromhex(data)
+    except ValueError:
+        return default
+    return int.from_bytes(raw[:4], byteorder="little")
+
+
+class WyBotF1RuntimeSensor(WyBotSensorBase):
+    """Sensor for F1 total runtime in seconds (DP 25, falling back to DP 111).
+
+    These DP ids were identified from a BLE sweep rather than the vendor app,
+    so the sensor is diagnostic and disabled by default. It is also BLE-only —
+    neither DP is delivered over the MQTT cloud stream.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_translation_key = "total_runtime"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_total_runtime"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "Total runtime"
 
     @property
     def native_value(self) -> int | None:
+        """Return the total runtime in seconds."""
         if not self._data:
             return None
-        val = _get_dp_le_value(self._data, "25")
-        if val == 0:
-            val = _get_dp_le_value(self._data, "111")
-        return val if val > 0 else None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["dp_25"] = _get_dp_le_value(self._data, "25")
-            attrs["dp_111"] = _get_dp_le_value(self._data, "111")
-            attrs["dp_56"] = _get_dp_le_value(self._data, "56")
-            attrs["dp_54"] = _get_dp_le_value(self._data, "54")
-        return attrs
+        val = _get_dp_le_value(self._data, "25") or _get_dp_le_value(self._data, "111")
+        return val or None
 
 
 class WyBotF1CycleRuntimeSensor(WyBotSensorBase):
-    """Sensor for F1 current/last cycle runtime in seconds (DP 55 / DP 129)."""
+    """Sensor for F1 current/last cycle runtime (DP 55, falling back to DP 129).
 
-    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
-    _attr_device_class = SensorDeviceClass.DURATION
+    Identified from a BLE sweep rather than the vendor app, so this is
+    diagnostic, disabled by default, and BLE-only.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_translation_key = "cycle_runtime"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_cycle_runtime"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "Cycle runtime"
 
     @property
     def native_value(self) -> int | None:
+        """Return the cycle runtime in seconds."""
         if not self._data:
             return None
-        val = _get_dp_le_value(self._data, "55")
-        if val == 0:
-            val = _get_dp_le_value(self._data, "129")
-        return val if val > 0 else None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["dp_55"] = _get_dp_le_value(self._data, "55")
-            attrs["dp_129"] = _get_dp_le_value(self._data, "129")
-            attrs["dp_110"] = _get_dp_le_value(self._data, "110")
-        return attrs
-
-
-class WyBotF1WaterTempSensor(WyBotSensorBase):
-    """Sensor for F1 water temperature (DP 30, guessed °C)."""
-
-    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
-    _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = "°C"
-    _attr_translation_key = "water_temperature"
-
-    @property
-    def unique_id(self) -> str:
-        return f"wybot_{self._idx}_f1_water_temp"
-
-    @property
-    def name(self) -> str:
-        return "Water temperature"
-
-    @property
-    def native_value(self) -> int | None:
-        if not self._data:
-            return None
-        val = _get_dp_le_value(self._data, "30")
-        return val if val > 0 else None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["dp_30_raw"] = _get_dp_raw(self._data, "30")
-            attrs["dp_30_f"] = round(_get_dp_le_value(self._data, "30") * 9/5 + 32, 1) if _get_dp_le_value(self._data, "30") > 0 else None
-        return attrs
+        val = _get_dp_le_value(self._data, "55") or _get_dp_le_value(self._data, "129")
+        return val or None
 
 
 class WyBotF1TotalEnergySensor(WyBotSensorBase):
-    """Sensor for F1 total energy (DP 34, guessed Wh)."""
+    """Sensor for F1 total energy (DP 34).
 
-    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
-    _attr_device_class = SensorDeviceClass.ENERGY
+    The unit is inferred, not confirmed by the vendor app, so this is
+    diagnostic, disabled by default, and BLE-only.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
@@ -733,69 +688,51 @@ class WyBotF1TotalEnergySensor(WyBotSensorBase):
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_total_energy"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "Total energy"
 
     @property
     def native_value(self) -> int | None:
+        """Return the total energy."""
         if not self._data:
             return None
-        val = _get_dp_le_value(self._data, "34")
-        return val if val > 0 else None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["dp_34"] = _get_dp_le_value(self._data, "34")
-            attrs["dp_133"] = _get_dp_le_value(self._data, "133")
-            attrs["dp_53"] = _get_dp_le_value(self._data, "53")
-            attrs["dp_54"] = _get_dp_le_value(self._data, "54")
-            attrs["dp_56"] = _get_dp_le_value(self._data, "56")
-        return attrs
+        return _get_dp_le_value(self._data, "34") or None
 
 
 class WyBotF1MotorPWMSensor(WyBotSensorBase):
-    """Sensor for F1 motor PWM values (DP 81-85).
+    """Sensor for the F1 pump motor PWM duty cycle (DP 81).
 
-    Shows the primary motor speed as state, all values as attributes.
+    DPs 82-85 carry the remaining motors but their mapping is unconfirmed, so
+    only the pump is exposed. Diagnostic, disabled by default, and BLE-only.
     """
 
-    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = "%"
+    _attr_native_unit_of_measurement = PERCENTAGE
     _attr_translation_key = "motor_pwm"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_motor_pwm"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "Motor PWM"
 
     @property
     def native_value(self) -> int | None:
+        """Return the pump motor PWM duty cycle."""
         if not self._data:
             return None
-        val = _get_dp_le_value(self._data, "81")
-        return val if val > 0 else None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["dp_81_pump"] = _get_dp_le_value(self._data, "81")
-            attrs["dp_82_drive"] = _get_dp_le_value(self._data, "82")
-            attrs["dp_83_brush"] = _get_dp_le_value(self._data, "83")
-            attrs["dp_84_setting"] = _get_dp_le_value(self._data, "84")
-            attrs["dp_85_setting2"] = _get_dp_le_value(self._data, "85")
-            attrs["dp_61_voltage_mv"] = _get_dp_le_value(self._data, "61")
-        return attrs
+        return _get_dp_le_value(self._data, "81") or None
 
 
 
@@ -819,30 +756,13 @@ class WyBotF1CleaningModeSensor(WyBotSensorBase):
 
     @property
     def native_value(self) -> str | None:
+        """Return the current cleaning mode."""
         if not self._data:
             return None
         mode_dp = self._data.get_dp(CleaningMode)
         if mode_dp is None or mode_dp.data is None:
             return None
-        mode_val = int(mode_dp.data, 16)
-        # F1 modes
-        f1_modes = {14: "Smart", 15: "Standard"}
-        if mode_val in f1_modes:
-            return f1_modes[mode_val]
-        # DS20 modes
-        if mode_val < len(CleaningMode.CLEANING_MODES):
-            return mode_dp.cleaning_mode
-        return f"Unknown ({mode_val})"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            mode_dp = self._data.get_dp(CleaningMode)
-            if mode_dp is not None and mode_dp.data is not None:
-                attrs["raw_value"] = int(mode_dp.data, 16)
-                attrs["raw_hex"] = mode_dp.data
-        return attrs
+        return mode_dp.cleaning_mode
 
 
 # =============================================================================
@@ -859,32 +779,26 @@ class WyBotF1HeavyDirtSensor(WyBotSensorBase):
 
     _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
     _attr_translation_key = "heavy_dirt"
-    _attr_translation_key = "heavy_dirt"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_heavy_dirt"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "Heavy dirt mode"
 
     @property
     def native_value(self) -> str | None:
+        """Return whether heavy dirt mode is engaged."""
         if not self._data:
             return None
-        dp = _get_dp_raw(self._data, "145")
-        if dp is None:
+        dp = self._data.get_dp(HeavyDirtMode)
+        if dp is None or dp.data is None:
             return None
-        val = int(dp, 16)
-        return "Enabled" if val > 0 else "Disabled"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["raw_value"] = _get_dp_le_value(self._data, "145")
-        return attrs
+        return "Enabled" if dp.is_enabled else "Disabled"
 
 
 class WyBotF1InWaterSensor(WyBotSensorBase):
@@ -895,32 +809,26 @@ class WyBotF1InWaterSensor(WyBotSensorBase):
 
     _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
     _attr_translation_key = "in_water"
-    _attr_translation_key = "in_water"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_in_water"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "In water"
 
     @property
     def native_value(self) -> str | None:
+        """Return whether the skimmer reports itself in the water."""
         if not self._data:
             return None
         dp = _get_dp_raw(self._data, "212")
         if dp is None:
             return None
-        val = int(dp, 16)
-        return "Yes" if val > 0 else "No"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["raw_value"] = _get_dp_le_value(self._data, "212")
-        return attrs
+        return "Yes" if int(dp, 16) > 0 else "No"
 
 
 class WyBotF1SonarSensor(WyBotSensorBase):
@@ -931,32 +839,26 @@ class WyBotF1SonarSensor(WyBotSensorBase):
 
     _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
     _attr_translation_key = "sonar"
-    _attr_translation_key = "sonar"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_sonar"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "Sonar"
 
     @property
     def native_value(self) -> str | None:
+        """Return whether the sonar is active."""
         if not self._data:
             return None
         dp = _get_dp_raw(self._data, "209")
         if dp is None:
             return None
-        val = int(dp, 16)
-        return "Active" if val > 0 else "Inactive"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            attrs["raw_value"] = _get_dp_le_value(self._data, "209")
-        return attrs
+        return "Active" if int(dp, 16) > 0 else "Inactive"
 
 
 class WyBotF1PhSensor(WyBotSensorBase):
@@ -966,42 +868,37 @@ class WyBotF1PhSensor(WyBotSensorBase):
     """
 
     _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
-    _attr_device_class = None
-    _attr_device_class = None
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "pH"
     _attr_translation_key = "ph_value"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_ph"
 
     @property
     def name(self) -> str:
+        """Return the name of the sensor."""
         return "pH"
 
     @property
     def native_value(self) -> float | None:
+        """Return the pH reading from the electrode."""
         if not self._data:
             return None
-        dp = _get_dp_raw(self._data, "142")
-        if dp is None or len(dp) < 4:
+        ph_data = self._data.get_dp(PhData)
+        if ph_data is None:
             return None
-        try:
-            return int(dp[:4], 16) / 100.0
-        except (ValueError, IndexError):
-            return None
+        return ph_data.ph_value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            dp = _get_dp_raw(self._data, "142")
-            if dp and len(dp) >= 8:
-                attrs["raw_hex"] = dp
-                try:
-                    attrs["temp_from_ph"] = int(dp[4:8], 16) / 10.0
-                except (ValueError, IndexError):
-                    pass
-        return attrs
+        """Return the electrode temperature alongside the pH reading."""
+        if not self._data:
+            return {}
+        ph_data = self._data.get_dp(PhData)
+        if ph_data is None or ph_data.temperature is None:
+            return {}
+        return {"electrode_temperature": ph_data.temperature}
 

--- a/custom_components/wybot/sensor.py
+++ b/custom_components/wybot/sensor.py
@@ -20,9 +20,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import WyBotConfigEntry
 from .const import DOMAIN, MANUFACTURER
 from .wybot_coordinator import WyBotCoordinator
+import json as json_module
+
 from wybot.dp_models import (
     Battery,
+    CleaningMode,
     DockInfo,
+    GenericDP,
     SolarDockBattery,
     SolarEnergyHarvested,
 )
@@ -66,6 +70,21 @@ async def async_setup_entry(
                     WyBotSolarDockBatterySensor(idx=device_id, coordinator=coordinator),
                     WyBotSolarEnergySensor(idx=device_id, coordinator=coordinator),
                     WyBotDockTypeSensor(idx=device_id, coordinator=coordinator),
+                    # F1-specific: integrated solar battery (reads DP 50 middle byte)
+                    WyBotF1SolarBatterySensor(idx=device_id, coordinator=coordinator),
+                    # F1-specific: runtime, temperature, energy sensors
+                    WyBotF1RuntimeSensor(idx=device_id, coordinator=coordinator),
+                    WyBotF1CycleRuntimeSensor(idx=device_id, coordinator=coordinator),
+                    WyBotF1WaterTempSensor(idx=device_id, coordinator=coordinator),
+                    WyBotF1TotalEnergySensor(idx=device_id, coordinator=coordinator),
+                    WyBotF1MotorPWMSensor(idx=device_id, coordinator=coordinator),
+                    # F1 cleaning mode sensor
+                    WyBotF1CleaningModeSensor(idx=device_id, coordinator=coordinator),
+                    # APK-confirmed DP sensors
+                    WyBotF1HeavyDirtSensor(idx=device_id, coordinator=coordinator),
+                    WyBotF1InWaterSensor(idx=device_id, coordinator=coordinator),
+                    WyBotF1SonarSensor(idx=device_id, coordinator=coordinator),
+                    WyBotF1PhSensor(idx=device_id, coordinator=coordinator),
                     # Diagnostic sensors for communication tracking
                     WyBotLastBLECommunicationSensor(idx=device_id, coordinator=coordinator),
                     WyBotLastMQTTCommunicationSensor(idx=device_id, coordinator=coordinator),
@@ -239,18 +258,32 @@ class WyBotSolarDockBatterySensor(WyBotDockSensorBase):
         """Return the solar dock battery level as percentage."""
         if not self._data:
             return None
+        # DS20 dock: uses DP 221
         dock_battery = self._data.get_dp(SolarDockBattery)
-        if dock_battery is None:
-            return None
-        return dock_battery.battery_level
+        if dock_battery is not None:
+            return dock_battery.battery_level
+        # F1 fallback: DP 50 has 3 bytes [charge_state][solar_battery%][robot_battery%]
+        battery = self._data.get_dp(Battery)
+        if battery is not None and battery.data and len(battery.data) >= 6:
+            # Middle byte (hex chars 2-3) is the solar/integrated battery %
+            try:
+                return int(battery.data[2:4], 16)
+            except (ValueError, IndexError):
+                pass
+        return None
 
 
 class WyBotSolarEnergySensor(WyBotDockSensorBase):
-    """Sensor for total solar energy harvested."""
+    """Sensor for total working time (DP 131).
 
-    _attr_device_class = SensorDeviceClass.ENERGY
+    Previously labeled 'Energy harvested' — APK analysis revealed DP 131 (0x83)
+    is actually 'working time' in seconds, not energy in Wh.
+    Kept the class name for entity ID stability but changed unit to seconds.
+    """
+
+    _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+    _attr_native_unit_of_measurement = "s"
     _attr_translation_key = "solar_energy"
 
     @property
@@ -261,17 +294,29 @@ class WyBotSolarEnergySensor(WyBotDockSensorBase):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return "Energy harvested"
+        return "Working time"
 
     @property
     def native_value(self) -> int | None:
-        """Return the total solar energy harvested in Wh."""
+        """Return the total working time in seconds."""
         if not self._data:
             return None
-        solar_energy = self._data.get_dp(SolarEnergyHarvested)
-        if solar_energy is None:
-            return None
-        return solar_energy.energy_wh
+        # DP 131 (0x83) = working time (confirmed by APK, was SolarEnergyHarvested)
+        working_time = self._data.get_dp(SolarEnergyHarvested)
+        if working_time is not None:
+            # Use the old class's energy_wh property which actually reads LE 4-byte value
+            return working_time.energy_wh  # This is actually seconds, not Wh
+        # F1 fallback: DP 18 (type=2, 4-byte LE) from dock MQTT
+        if self._data and self._data.docker:
+            dp18 = self._data.docker.dps.get("18")
+            if dp18 and dp18.data:
+                try:
+                    raw = bytes.fromhex(dp18.data)
+                    if len(raw) >= 4:
+                        return int.from_bytes(raw[:4], byteorder="little")
+                except (ValueError, IndexError):
+                    pass
+        return None
 
 
 class WyBotDockTypeSensor(WyBotDockSensorBase):
@@ -336,11 +381,12 @@ class WyBotLastBLECommunicationSensor(WyBotDockSensorBase):
     @property
     def native_value(self) -> datetime | None:
         """Return the last BLE communication time."""
-        # Get the dock device ID for BLE tracking (dock relays to robot)
-        if self._data and self._data.docker:
-            device_id = self._data.docker.docker_id
-        elif self._data and self._data.device:
+        # Get the device ID for BLE tracking
+        # Prefer device ID since coordinator stores BLE status under device, not docker
+        if self._data and self._data.device and self._data.device.device_id:
             device_id = self._data.device.device_id
+        elif self._data and self._data.docker and self._data.docker.docker_id:
+            device_id = self._data.docker.docker_id
         else:
             return None
         return self._coordinator.get_last_ble_communication(device_id)
@@ -349,11 +395,11 @@ class WyBotLastBLECommunicationSensor(WyBotDockSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         attrs: dict[str, Any] = {}
-        if self._data and self._data.docker:
-            device_id = self._data.docker.docker_id
+        if self._data and self._data.device and self._data.device.device_id:
+            device_id = self._data.device.device_id
             attrs["ble_available"] = self._coordinator.is_ble_available(device_id)
-            if self._data.docker.ble_name:
-                attrs["ble_name"] = self._data.docker.ble_name
+        if self._data and self._data.docker and self._data.docker.ble_name:
+            attrs["ble_name"] = self._data.docker.ble_name
         return attrs
 
 
@@ -378,11 +424,11 @@ class WyBotLastMQTTCommunicationSensor(WyBotDockSensorBase):
     @property
     def native_value(self) -> datetime | None:
         """Return the last MQTT communication time."""
-        # Get the dock device ID for MQTT tracking
-        if self._data and self._data.docker:
-            device_id = self._data.docker.docker_id
-        elif self._data and self._data.device:
+        # Get the device ID for MQTT tracking
+        if self._data and self._data.device and self._data.device.device_id:
             device_id = self._data.device.device_id
+        elif self._data and self._data.docker and self._data.docker.docker_id:
+            device_id = self._data.docker.docker_id
         else:
             return None
         return self._coordinator.get_last_mqtt_communication(device_id)
@@ -391,8 +437,7 @@ class WyBotLastMQTTCommunicationSensor(WyBotDockSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         attrs: dict[str, Any] = {}
-        if self._data and self._data.docker:
-            attrs["mqtt_connected"] = self._coordinator._mqtt_connected
+        attrs["mqtt_connected"] = self._coordinator._mqtt_connected
         return attrs
 
 
@@ -417,10 +462,10 @@ class WyBotDataSourceSensor(WyBotDockSensorBase):
     @property
     def native_value(self) -> str | None:
         """Return the current data source."""
-        if self._data and self._data.docker:
-            device_id = self._data.docker.docker_id
-        elif self._data and self._data.device:
+        if self._data and self._data.device and self._data.device.device_id:
             device_id = self._data.device.device_id
+        elif self._data and self._data.docker and self._data.docker.docker_id:
+            device_id = self._data.docker.docker_id
         else:
             return None
         source = self._coordinator.get_data_source(device_id)
@@ -433,10 +478,10 @@ class WyBotDataSourceSensor(WyBotDockSensorBase):
     @property
     def icon(self) -> str:
         """Return the icon based on data source."""
-        if self._data and self._data.docker:
-            device_id = self._data.docker.docker_id
-        elif self._data and self._data.device:
+        if self._data and self._data.device and self._data.device.device_id:
             device_id = self._data.device.device_id
+        elif self._data and self._data.docker and self._data.docker.docker_id:
+            device_id = self._data.docker.docker_id
         else:
             return "mdi:help-circle"
         source = self._coordinator.get_data_source(device_id)
@@ -450,17 +495,508 @@ class WyBotDataSourceSensor(WyBotDockSensorBase):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         attrs: dict[str, Any] = {}
-        if self._data and self._data.docker:
+        if self._data and self._data.device and self._data.device.device_id:
+            device_id = self._data.device.device_id
+        elif self._data and self._data.docker and self._data.docker.docker_id:
             device_id = self._data.docker.docker_id
-            attrs["ble_available"] = self._coordinator.is_ble_available(device_id)
-            attrs["mqtt_connected"] = self._coordinator._mqtt_connected
-            last_ble = self._coordinator.get_last_ble_communication(device_id)
-            last_mqtt = self._coordinator.get_last_mqtt_communication(device_id)
-            if last_ble:
-                attrs["last_ble"] = last_ble.isoformat()
-            if last_mqtt:
-                attrs["last_mqtt"] = last_mqtt.isoformat()
-            mqtt_connected_at = self._coordinator._mqtt_last_connected_at
-            if mqtt_connected_at:
-                attrs["mqtt_last_connected_at"] = mqtt_connected_at.isoformat()
+        else:
+            return attrs
+        attrs["ble_available"] = self._coordinator.is_ble_available(device_id)
+        attrs["mqtt_connected"] = self._coordinator._mqtt_connected
+        last_ble = self._coordinator.get_last_ble_communication(device_id)
+        last_mqtt = self._coordinator.get_last_mqtt_communication(device_id)
+        if last_ble:
+            attrs["last_ble"] = last_ble.isoformat()
+        if last_mqtt:
+            attrs["last_mqtt"] = last_mqtt.isoformat()
+        mqtt_connected_at = self._coordinator._mqtt_last_connected_at
+        if mqtt_connected_at:
+            attrs["mqtt_last_connected_at"] = mqtt_connected_at.isoformat()
         return attrs
+
+
+class WyBotF1SolarBatterySensor(WyBotSensorBase):
+    """Sensor for F1 integrated solar battery level.
+
+    The F1 skimmer has an integrated solar panel and battery, unlike the
+    S2 Pro which uses a separate DS20 dock. The solar battery percentage
+    is encoded in the middle byte of DP 50 (Battery):
+      - Byte 0: charge_state (0=not_plugged, 1=charging, 2=charged)
+      - Byte 1: solar battery % (F1-specific, not present on DS20)
+      - Byte 2: robot battery %
+    """
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_translation_key = "dock_battery"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"wybot_{self._idx}_f1_solar_battery"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return "Solar battery"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the F1 integrated solar battery level as percentage."""
+        if not self._data:
+            return None
+        battery = self._data.get_dp(Battery)
+        if battery is None or not battery.data:
+            return None
+        # F1 sends 3 bytes for DP 50: [charge_state][solar_battery%][robot_battery%]
+        # Standard DS20 sends 2 bytes, so only parse middle byte if 3+ bytes present
+        if len(battery.data) >= 6:  # 3 bytes = 6 hex chars
+            try:
+                return int(battery.data[2:4], 16)
+            except (ValueError, IndexError):
+                pass
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes."""
+        attrs: dict[str, Any] = {}
+        if self._data:
+            battery = self._data.get_dp(Battery)
+            if battery is not None:
+                attrs["raw_data"] = battery.data
+                attrs["charge_state"] = battery.charge_state.name
+                attrs["robot_battery"] = battery.battery_level
+        return attrs
+
+
+# =============================================================================
+# F1-Specific Sensors
+# =============================================================================
+
+
+def _get_dp_le_value(group, dp_id: str, default: int = 0) -> int:
+    """Get a DP value as little-endian integer from either device or docker."""
+    if not group:
+        return default
+    # Check device DPs first
+    dp = group.device.dps.get(str(dp_id)) if group.device else None
+    if dp is None and group.docker:
+        dp = group.docker.dps.get(str(dp_id))
+    if dp is None or not dp.data:
+        return default
+    try:
+        raw = bytes.fromhex(dp.data)
+        if len(raw) >= 4:
+            return int.from_bytes(raw[:4], byteorder="little")
+        return int.from_bytes(raw, byteorder="little")
+    except (ValueError, IndexError):
+        return default
+
+
+def _get_dp_raw(group, dp_id: str) -> str | None:
+    """Get raw DP data hex string from device or docker."""
+    if not group:
+        return None
+    dp = group.device.dps.get(str(dp_id)) if group.device else None
+    if dp is None and group.docker:
+        dp = group.docker.dps.get(str(dp_id))
+    if dp is None or not dp.data:
+        return None
+    return dp.data
+
+
+class WyBotF1RuntimeSensor(WyBotSensorBase):
+    """Sensor for F1 total runtime in seconds (DP 25 / DP 111)."""
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "s"
+    _attr_translation_key = "total_runtime"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_total_runtime"
+
+    @property
+    def name(self) -> str:
+        return "Total runtime"
+
+    @property
+    def native_value(self) -> int | None:
+        if not self._data:
+            return None
+        val = _get_dp_le_value(self._data, "25")
+        if val == 0:
+            val = _get_dp_le_value(self._data, "111")
+        return val if val > 0 else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["dp_25"] = _get_dp_le_value(self._data, "25")
+            attrs["dp_111"] = _get_dp_le_value(self._data, "111")
+            attrs["dp_56"] = _get_dp_le_value(self._data, "56")
+            attrs["dp_54"] = _get_dp_le_value(self._data, "54")
+        return attrs
+
+
+class WyBotF1CycleRuntimeSensor(WyBotSensorBase):
+    """Sensor for F1 current/last cycle runtime in seconds (DP 55 / DP 129)."""
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "s"
+    _attr_translation_key = "cycle_runtime"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_cycle_runtime"
+
+    @property
+    def name(self) -> str:
+        return "Cycle runtime"
+
+    @property
+    def native_value(self) -> int | None:
+        if not self._data:
+            return None
+        val = _get_dp_le_value(self._data, "55")
+        if val == 0:
+            val = _get_dp_le_value(self._data, "129")
+        return val if val > 0 else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["dp_55"] = _get_dp_le_value(self._data, "55")
+            attrs["dp_129"] = _get_dp_le_value(self._data, "129")
+            attrs["dp_110"] = _get_dp_le_value(self._data, "110")
+        return attrs
+
+
+class WyBotF1WaterTempSensor(WyBotSensorBase):
+    """Sensor for F1 water temperature (DP 30, guessed °C)."""
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "°C"
+    _attr_translation_key = "water_temperature"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_water_temp"
+
+    @property
+    def name(self) -> str:
+        return "Water temperature"
+
+    @property
+    def native_value(self) -> int | None:
+        if not self._data:
+            return None
+        val = _get_dp_le_value(self._data, "30")
+        return val if val > 0 else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["dp_30_raw"] = _get_dp_raw(self._data, "30")
+            attrs["dp_30_f"] = round(_get_dp_le_value(self._data, "30") * 9/5 + 32, 1) if _get_dp_le_value(self._data, "30") > 0 else None
+        return attrs
+
+
+class WyBotF1TotalEnergySensor(WyBotSensorBase):
+    """Sensor for F1 total energy (DP 34, guessed Wh)."""
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
+    _attr_translation_key = "total_energy"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_total_energy"
+
+    @property
+    def name(self) -> str:
+        return "Total energy"
+
+    @property
+    def native_value(self) -> int | None:
+        if not self._data:
+            return None
+        val = _get_dp_le_value(self._data, "34")
+        return val if val > 0 else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["dp_34"] = _get_dp_le_value(self._data, "34")
+            attrs["dp_133"] = _get_dp_le_value(self._data, "133")
+            attrs["dp_53"] = _get_dp_le_value(self._data, "53")
+            attrs["dp_54"] = _get_dp_le_value(self._data, "54")
+            attrs["dp_56"] = _get_dp_le_value(self._data, "56")
+        return attrs
+
+
+class WyBotF1MotorPWMSensor(WyBotSensorBase):
+    """Sensor for F1 motor PWM values (DP 81-85).
+
+    Shows the primary motor speed as state, all values as attributes.
+    """
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "%"
+    _attr_translation_key = "motor_pwm"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_motor_pwm"
+
+    @property
+    def name(self) -> str:
+        return "Motor PWM"
+
+    @property
+    def native_value(self) -> int | None:
+        if not self._data:
+            return None
+        val = _get_dp_le_value(self._data, "81")
+        return val if val > 0 else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["dp_81_pump"] = _get_dp_le_value(self._data, "81")
+            attrs["dp_82_drive"] = _get_dp_le_value(self._data, "82")
+            attrs["dp_83_brush"] = _get_dp_le_value(self._data, "83")
+            attrs["dp_84_setting"] = _get_dp_le_value(self._data, "84")
+            attrs["dp_85_setting2"] = _get_dp_le_value(self._data, "85")
+            attrs["dp_61_voltage_mv"] = _get_dp_le_value(self._data, "61")
+        return attrs
+
+
+
+class WyBotF1CleaningModeSensor(WyBotSensorBase):
+    """Sensor for F1 cleaning mode (DP 1).
+
+    Shows the current cleaning mode as a string:
+    - DS20: Floor, Wall, Wall Then Floor, Advanced Full Pool, Water Line, Turbo Floor, Eco Floor
+    - F1: Standard (0x0f=15), Smart (0x0e=14)
+    """
+
+    _attr_translation_key = "cleaning_mode"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_cleaning_mode"
+
+    @property
+    def name(self) -> str:
+        return "Cleaning mode"
+
+    @property
+    def native_value(self) -> str | None:
+        if not self._data:
+            return None
+        mode_dp = self._data.get_dp(CleaningMode)
+        if mode_dp is None or mode_dp.data is None:
+            return None
+        mode_val = int(mode_dp.data, 16)
+        # F1 modes
+        f1_modes = {14: "Smart", 15: "Standard"}
+        if mode_val in f1_modes:
+            return f1_modes[mode_val]
+        # DS20 modes
+        if mode_val < len(CleaningMode.CLEANING_MODES):
+            return mode_dp.cleaning_mode
+        return f"Unknown ({mode_val})"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            mode_dp = self._data.get_dp(CleaningMode)
+            if mode_dp is not None and mode_dp.data is not None:
+                attrs["raw_value"] = int(mode_dp.data, 16)
+                attrs["raw_hex"] = mode_dp.data
+        return attrs
+
+
+# =============================================================================
+# APK-Confirmed DP Sensors
+# =============================================================================
+
+
+
+class WyBotF1HeavyDirtSensor(WyBotSensorBase):
+    """Sensor for F1 heavy dirt mode (DP 145 / 0x91).
+
+    APK: "check mqtt delay DP_ID:OX91 heavyDirt mode: "
+    """
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_translation_key = "heavy_dirt"
+    _attr_translation_key = "heavy_dirt"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_heavy_dirt"
+
+    @property
+    def name(self) -> str:
+        return "Heavy dirt mode"
+
+    @property
+    def native_value(self) -> str | None:
+        if not self._data:
+            return None
+        dp = _get_dp_raw(self._data, "145")
+        if dp is None:
+            return None
+        val = int(dp, 16)
+        return "Enabled" if val > 0 else "Disabled"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["raw_value"] = _get_dp_le_value(self._data, "145")
+        return attrs
+
+
+class WyBotF1InWaterSensor(WyBotSensorBase):
+    """Sensor for F1 in-water state (DP 212 / 0xD4).
+
+    APK: "DP_ID: 0XD4 inWaterState"
+    """
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_translation_key = "in_water"
+    _attr_translation_key = "in_water"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_in_water"
+
+    @property
+    def name(self) -> str:
+        return "In water"
+
+    @property
+    def native_value(self) -> str | None:
+        if not self._data:
+            return None
+        dp = _get_dp_raw(self._data, "212")
+        if dp is None:
+            return None
+        val = int(dp, 16)
+        return "Yes" if val > 0 else "No"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["raw_value"] = _get_dp_le_value(self._data, "212")
+        return attrs
+
+
+class WyBotF1SonarSensor(WyBotSensorBase):
+    """Sensor for F1 sonar state (DP 209 / 0xD1).
+
+    APK: "DP_ID: 0XD1 sona state"
+    """
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_translation_key = "sonar"
+    _attr_translation_key = "sonar"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_sonar"
+
+    @property
+    def name(self) -> str:
+        return "Sonar"
+
+    @property
+    def native_value(self) -> str | None:
+        if not self._data:
+            return None
+        dp = _get_dp_raw(self._data, "209")
+        if dp is None:
+            return None
+        val = int(dp, 16)
+        return "Active" if val > 0 else "Inactive"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            attrs["raw_value"] = _get_dp_le_value(self._data, "209")
+        return attrs
+
+
+class WyBotF1PhSensor(WyBotSensorBase):
+    """Sensor for F1 pH value (DP 142 / 0x8E).
+
+    APK: "parseBLEData: PH_DATA:0X8E, pHvalue: "
+    """
+
+    _attr_entity_registry_enabled_default = False  # BLE-only, not available via MQTT
+    _attr_device_class = None
+    _attr_device_class = None
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "pH"
+    _attr_translation_key = "ph_value"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_ph"
+
+    @property
+    def name(self) -> str:
+        return "pH"
+
+    @property
+    def native_value(self) -> float | None:
+        if not self._data:
+            return None
+        dp = _get_dp_raw(self._data, "142")
+        if dp is None or len(dp) < 4:
+            return None
+        try:
+            return int(dp[:4], 16) / 100.0
+        except (ValueError, IndexError):
+            return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            dp = _get_dp_raw(self._data, "142")
+            if dp and len(dp) >= 8:
+                attrs["raw_hex"] = dp
+                try:
+                    attrs["temp_from_ph"] = int(dp[4:8], 16) / 10.0
+                except (ValueError, IndexError):
+                    pass
+        return attrs
+

--- a/custom_components/wybot/sensor.py
+++ b/custom_components/wybot/sensor.py
@@ -226,13 +226,18 @@ class WyBotRobotBatterySensor(WyBotSensorBase):
 
     @property
     def native_value(self) -> int | None:
-        """Return the robot battery level as percentage."""
+        """Return the robot battery level as percentage.
+
+        On the F1, the robot battery byte only updates when physically plugged in.
+        When charge_state is NOT_PLUGGED_IN on the F1 (3-byte DP 50), the value is
+        stale — return None so HA shows "unknown" instead of a misleading percentage.
+        """
         if not self._data:
             return None
         battery = self._data.get_dp(Battery)
         if battery is None:
             return None
-        return battery.battery_level
+        return battery.robot_battery_level
 
 
 class WyBotSolarDockBatterySensor(WyBotDockSensorBase):
@@ -567,7 +572,7 @@ class WyBotF1SolarBatterySensor(WyBotSensorBase):
             if battery is not None:
                 attrs["raw_data"] = battery.data
                 attrs["charge_state"] = battery.charge_state.name
-                attrs["robot_battery"] = battery.battery_level
+                attrs["robot_battery"] = battery.robot_battery_level
         return attrs
 
 

--- a/custom_components/wybot/strings.json
+++ b/custom_components/wybot/strings.json
@@ -65,7 +65,7 @@
       "wifi_password_required": "WiFi password is required when WiFi SSID is provided"
     }
   },
-    "entity": {
+  "entity": {
     "binary_sensor": {
       "robot_charging": {
         "name": "Charging"
@@ -89,9 +89,6 @@
       "dock_battery": {
         "name": "Dock battery"
       },
-      "solar_energy": {
-        "name": "Working time"
-      },
       "dock_type": {
         "name": "Dock type"
       },
@@ -109,9 +106,6 @@
       },
       "cycle_runtime": {
         "name": "Cycle runtime"
-      },
-      "water_temperature": {
-        "name": "Water temperature"
       },
       "total_energy": {
         "name": "Total energy"
@@ -133,6 +127,9 @@
       },
       "ph_value": {
         "name": "pH"
+      },
+      "working_time": {
+        "name": "Working time"
       }
     },
     "switch": {
@@ -150,6 +147,9 @@
     },
     "wifi_send_failed": {
       "message": "Failed to send WiFi credentials to dock {device} via Bluetooth."
+    },
+    "invalid_fan_speed": {
+      "message": "{fan_speed} is not a supported cleaning mode for this device. Supported modes: {fan_speed_list}."
     }
   }
 }

--- a/custom_components/wybot/strings.json
+++ b/custom_components/wybot/strings.json
@@ -65,13 +65,16 @@
       "wifi_password_required": "WiFi password is required when WiFi SSID is provided"
     }
   },
-  "entity": {
+    "entity": {
     "binary_sensor": {
       "robot_charging": {
         "name": "Charging"
       },
       "dock_charging": {
         "name": "Charging"
+      },
+      "fully_charged": {
+        "name": "Fully charged"
       }
     },
     "button": {
@@ -87,7 +90,7 @@
         "name": "Dock battery"
       },
       "solar_energy": {
-        "name": "Solar energy harvested"
+        "name": "Working time"
       },
       "dock_type": {
         "name": "Dock type"
@@ -100,6 +103,41 @@
       },
       "data_source": {
         "name": "Data source"
+      },
+      "total_runtime": {
+        "name": "Total runtime"
+      },
+      "cycle_runtime": {
+        "name": "Cycle runtime"
+      },
+      "water_temperature": {
+        "name": "Water temperature"
+      },
+      "total_energy": {
+        "name": "Total energy"
+      },
+      "motor_pwm": {
+        "name": "Motor PWM"
+      },
+      "cleaning_mode": {
+        "name": "Cleaning mode"
+      },
+      "heavy_dirt": {
+        "name": "Heavy dirt mode"
+      },
+      "in_water": {
+        "name": "In water"
+      },
+      "sonar": {
+        "name": "Sonar"
+      },
+      "ph_value": {
+        "name": "pH"
+      }
+    },
+    "switch": {
+      "auto_run": {
+        "name": "Auto run"
       }
     }
   },

--- a/custom_components/wybot/switch.py
+++ b/custom_components/wybot/switch.py
@@ -9,17 +9,18 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.exceptions import HomeAssistantError
 
 from . import WyBotConfigEntry
 from .const import DOMAIN, MANUFACTURER
 from .wybot_coordinator import WyBotCoordinator
-from wybot.dp_models import GenericDP, DP
+
+from wybot.dp_models import DP, AutoRunMode, GenericDP
 from wybot.models import Group
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,9 +51,11 @@ async def async_setup_entry(
             if device_id in known:
                 continue
             known.add(device_id)
-            entities.append(
-                WyBotF1AutoRunSwitch(idx=device_id, coordinator=coordinator)
-            )
+            # Auto-run is an F1 feature; DS20 robots ignore DP 207 entirely.
+            if coordinator.is_f1(device_id):
+                entities.append(
+                    WyBotF1AutoRunSwitch(idx=device_id, coordinator=coordinator)
+                )
         if entities:
             async_add_entities(entities)
 
@@ -132,18 +135,6 @@ class WyBotSwitchBase(SwitchEntity, CoordinatorEntity[WyBotCoordinator]):
         return cast(DeviceInfo, info_kwargs)
 
 
-def _get_dp_raw(group: Group | None, dp_id: str) -> str | None:
-    """Get raw DP data hex string from device or docker."""
-    if not group:
-        return None
-    dp = group.device.dps.get(str(dp_id)) if group.device else None
-    if dp is None and group.docker:
-        dp = group.docker.dps.get(str(dp_id))
-    if dp is None or not dp.data:
-        return None
-    return dp.data
-
-
 class WyBotF1AutoRunSwitch(WyBotSwitchBase):
     """Switch for F1 auto-run mode (DP 207 / 0xCF).
 
@@ -153,58 +144,44 @@ class WyBotF1AutoRunSwitch(WyBotSwitchBase):
 
     _attr_device_class = SwitchDeviceClass.SWITCH
     _attr_translation_key = "auto_run"
-    _attr_icon = "mdi:robot"
 
     @property
     def unique_id(self) -> str:
+        """Return a unique ID."""
         return f"wybot_{self._idx}_f1_auto_run_switch"
 
     @property
     def name(self) -> str:
+        """Return the name of the switch."""
         return "Auto run"
 
     @property
     def is_on(self) -> bool | None:
+        """Return whether auto-run is enabled."""
         if not self._data:
             return None
-        dp = _get_dp_raw(self._data, "207")
-        if dp is None:
+        auto_run = self._data.get_dp(AutoRunMode)
+        if auto_run is None or auto_run.data is None:
             return None
-        val = int(dp, 16)
-        return val > 0
+        return auto_run.is_enabled
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {}
-        if self._data:
-            raw = _get_dp_raw(self._data, "207")
-            attrs["raw_hex"] = raw
-            if raw is not None:
-                attrs["raw_value"] = int(raw, 16)
-            attrs["dp_id"] = "207 (0xCF)"
-        return attrs
+    async def _async_set_auto_run(self, enabled: bool) -> None:
+        """Write the auto-run flag to the device."""
+        if not self._data:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="device_unavailable"
+            )
+        dp = GenericDP(data=DP(id=207, type=4, len=1, data="01" if enabled else "00"))
+        if not await self.coordinator.async_send_command(self._data, dp):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="cannot_send_command"
+            )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable auto-run mode."""
-        if not self._data:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="device_unavailable"
-            )
-        dp = GenericDP(data=DP(id=207, type=4, len=1, data="01"))
-        if not await self.coordinator.async_send_command(self._data, dp):
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="cannot_send_command"
-            )
+        await self._async_set_auto_run(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable auto-run mode."""
-        if not self._data:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="device_unavailable"
-            )
-        dp = GenericDP(data=DP(id=207, type=4, len=1, data="00"))
-        if not await self.coordinator.async_send_command(self._data, dp):
-            raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="cannot_send_command"
-            )
+        await self._async_set_auto_run(False)
 

--- a/custom_components/wybot/switch.py
+++ b/custom_components/wybot/switch.py
@@ -1,0 +1,210 @@
+"""Switch platform for WyBot integration — auto-run toggle (DP 207 / 0xCF).
+
+APK: "parseBLEData: getAutoRunMode DP_ID_AUTO_RUN 0XCF mode: "
+When enabled, the robot starts skimming automatically when battery is sufficient.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from homeassistant.components.switch import SwitchEntity, SwitchDeviceClass
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.exceptions import HomeAssistantError
+
+from . import WyBotConfigEntry
+from .const import DOMAIN, MANUFACTURER
+from .wybot_coordinator import WyBotCoordinator
+from wybot.dp_models import GenericDP, DP
+from wybot.models import Group
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+def format_mac(mac: str) -> str:
+    """Format a MAC address string with colons."""
+    mac = mac.upper().replace(":", "").replace("-", "")
+    return ":".join(mac[i : i + 2] for i in range(0, 12, 2))
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WyBotConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the WyBot switch platform."""
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _add_new_devices() -> None:
+        """Add switch entities for devices discovered after setup."""
+        entities: list[SwitchEntity] = []
+        for device_id in coordinator.vacuums:
+            if device_id in known:
+                continue
+            known.add(device_id)
+            entities.append(
+                WyBotF1AutoRunSwitch(idx=device_id, coordinator=coordinator)
+            )
+        if entities:
+            async_add_entities(entities)
+
+    _add_new_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+
+
+class WyBotSwitchBase(SwitchEntity, CoordinatorEntity[WyBotCoordinator]):
+    """Base class for WyBot switches."""
+
+    _data: Group | None
+    _idx: str
+    _coordinator: WyBotCoordinator
+    _attr_has_entity_name = True
+
+    def __init__(self, idx: str, coordinator: WyBotCoordinator) -> None:
+        """Initialize the WyBot switch."""
+        super().__init__(coordinator=coordinator, context=idx)
+        self._idx = idx
+        self._coordinator = coordinator
+        self._data = coordinator.data.get(self._idx) if coordinator.data else None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if str(self._idx) in self.coordinator.data:
+            self._data = self.coordinator.data[str(self._idx)]
+        super()._handle_coordinator_update()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.available:
+            return False
+        if not self._data:
+            return False
+        if str(self._idx) not in self.coordinator.data:
+            return False
+        return True
+
+    def _get_robot_name(self) -> str:
+        """Get the robot device name."""
+        if self._data:
+            if self._data.name:
+                return self._data.name
+            elif self._data.device and self._data.device.device_name:
+                return self._data.device.device_name
+            elif self._data.device and self._data.device.device_type:
+                return self._data.device.device_type
+        return "Unknown"
+
+    def _get_robot_model(self) -> str:
+        """Get the robot device model."""
+        if self._data and self._data.device:
+            return self._data.device.device_type
+        return "Unknown"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for the robot."""
+        connections: set[tuple[str, str]] = set()
+        if self._data and self._data.device and self._data.device.ble_name:
+            connections.add(
+                (CONNECTION_BLUETOOTH, format_mac(self._data.device.ble_name))
+            )
+        via_device = None
+        if self._data and self._data.docker:
+            via_device = (DOMAIN, f"{self._idx}_dock")
+        info_kwargs: dict[str, Any] = {
+            "identifiers": {(DOMAIN, str(self._idx))},
+            "name": self._get_robot_name(),
+            "manufacturer": MANUFACTURER,
+            "model": self._get_robot_model(),
+            "connections": connections if connections else None,
+            "via_device": via_device,
+        }
+        return cast(DeviceInfo, info_kwargs)
+
+
+def _get_dp_raw(group: Group | None, dp_id: str) -> str | None:
+    """Get raw DP data hex string from device or docker."""
+    if not group:
+        return None
+    dp = group.device.dps.get(str(dp_id)) if group.device else None
+    if dp is None and group.docker:
+        dp = group.docker.dps.get(str(dp_id))
+    if dp is None or not dp.data:
+        return None
+    return dp.data
+
+
+class WyBotF1AutoRunSwitch(WyBotSwitchBase):
+    """Switch for F1 auto-run mode (DP 207 / 0xCF).
+
+    APK: "parseBLEData: getAutoRunMode DP_ID_AUTO_RUN 0XCF mode: "
+    When enabled, the robot starts skimming when battery is sufficient.
+    """
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_translation_key = "auto_run"
+    _attr_icon = "mdi:robot"
+
+    @property
+    def unique_id(self) -> str:
+        return f"wybot_{self._idx}_f1_auto_run_switch"
+
+    @property
+    def name(self) -> str:
+        return "Auto run"
+
+    @property
+    def is_on(self) -> bool | None:
+        if not self._data:
+            return None
+        dp = _get_dp_raw(self._data, "207")
+        if dp is None:
+            return None
+        val = int(dp, 16)
+        return val > 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if self._data:
+            raw = _get_dp_raw(self._data, "207")
+            attrs["raw_hex"] = raw
+            if raw is not None:
+                attrs["raw_value"] = int(raw, 16)
+            attrs["dp_id"] = "207 (0xCF)"
+        return attrs
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable auto-run mode."""
+        if not self._data:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="device_unavailable"
+            )
+        dp = GenericDP(data=DP(id=207, type=4, len=1, data="01"))
+        if not await self.coordinator.async_send_command(self._data, dp):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="cannot_send_command"
+            )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable auto-run mode."""
+        if not self._data:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="device_unavailable"
+            )
+        dp = GenericDP(data=DP(id=207, type=4, len=1, data="00"))
+        if not await self.coordinator.async_send_command(self._data, dp):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="cannot_send_command"
+            )
+

--- a/custom_components/wybot/vacuum.py
+++ b/custom_components/wybot/vacuum.py
@@ -307,6 +307,8 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
             | VacuumEntityFeature.RETURN_HOME
             | VacuumEntityFeature.START
             | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.TURN_ON
+            | VacuumEntityFeature.TURN_OFF
         )
 
     async def _async_send_command(self, dp: GenericDP) -> None:
@@ -341,6 +343,18 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         """Start the vacuum cleaner."""
         await self._async_send_command(
             CleaningStatus(status=CleaningStatusMode.CLEANING)
+        )
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the vacuum cleaner (alias for start)."""
+        await self._async_send_command(
+            CleaningStatus(status=CleaningStatusMode.CLEANING)
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the vacuum cleaner (alias for stop)."""
+        await self._async_send_command(
+            CleaningStatus(status=CleaningStatusMode.STOPPED)
         )
 
     async def async_return_to_base(self, **kwargs: Any) -> None:

--- a/custom_components/wybot/vacuum.py
+++ b/custom_components/wybot/vacuum.py
@@ -242,6 +242,18 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         if dock_status is not None and dock_status.status == DockStatus.RETURNING:
             return VacuumActivity.RETURNING
 
+        # Check cleaning status BEFORE dock status
+        # The F1 reports DP 11 = DOCKED even while cleaning (no real dock),
+        # so we must check DP 0 first to avoid showing "docked" during cleaning
+        if cleaning_status is not None:
+            if cleaning_status.status in (
+                CleaningStatusMode.CLEANING,
+                CleaningStatusMode.STARTING,
+            ):
+                return VacuumActivity.CLEANING
+            if cleaning_status.status == CleaningStatusMode.STOPPED:
+                return VacuumActivity.PAUSED
+
         # Check if docked - use dock status, dock connection status, or battery charging state
         is_docked = False
         if dock_status is not None and dock_status.status == DockStatus.DOCKED:
@@ -254,21 +266,20 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         if is_docked:
             return VacuumActivity.DOCKED
 
-        # Check cleaning status
-        if cleaning_status is not None:
-            if cleaning_status.status in (
-                CleaningStatusMode.CLEANING,
-                CleaningStatusMode.STARTING,
-            ):
-                return VacuumActivity.CLEANING
-            if cleaning_status.status == CleaningStatusMode.STOPPED:
-                return VacuumActivity.PAUSED
+        # F1-specific: 0x0f (15) = IDLE/STANDBY
+        if cleaning_status is not None and cleaning_status.status == CleaningStatusMode.UNKNOWN:
+            return VacuumActivity.IDLE if hasattr(VacuumActivity, 'IDLE') else None
 
         return None
 
+    # F1-specific cleaning modes (values 14-15, outside DS20's 0-6 range)
+    F1_CLEANING_MODES = {14: "Smart", 15: "Standard"}
+
     @property
     def fan_speed_list(self) -> list[str]:
-        """Flag vacuum cleaner robot features that are supported."""
+        """Return supported cleaning modes."""
+        if self._data and self._data.device and self._data.device.device_type == "WYF1":
+            return ["Standard", "Smart"]
         return CleaningMode.CLEANING_MODES
 
     @property
@@ -277,7 +288,14 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         if not self._data:
             return None
         fan_speed = self._data.get_dp(CleaningMode)
-        if fan_speed is not None:
+        if fan_speed is None or fan_speed.data is None:
+            return None
+        mode_val = int(fan_speed.data, 16)
+        # F1 modes
+        if mode_val in self.F1_CLEANING_MODES:
+            return self.F1_CLEANING_MODES[mode_val]
+        # DS20 modes
+        if mode_val < len(CleaningMode.CLEANING_MODES):
             return fan_speed.cleaning_mode
         return None
 
@@ -304,7 +322,14 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set the fan speed of the vacuum cleaner."""
-        await self._async_send_command(CleaningMode(mode=fan_speed))
+        # F1-specific modes
+        f1_mode_map = {"Standard": 15, "Smart": 14}
+        if fan_speed in f1_mode_map:
+            from wybot.dp_models import DP
+            dp = CleaningMode(data=DP(id=1, type=4, len=1, data=f"{f1_mode_map[fan_speed]:02x}"))
+            await self._async_send_command(dp)
+        else:
+            await self._async_send_command(CleaningMode(mode=fan_speed))
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""
@@ -321,3 +346,4 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
     async def async_return_to_base(self, **kwargs: Any) -> None:
         """Return the vacuum cleaner to the dock."""
         await self._async_send_command(Dock(status=DockStatus.RETURNING))
+

--- a/custom_components/wybot/vacuum.py
+++ b/custom_components/wybot/vacuum.py
@@ -12,7 +12,7 @@ from homeassistant.components.vacuum import (
     VacuumEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -41,6 +41,17 @@ PARALLEL_UPDATES = 1
 
 # Force state write every 5 minutes to ensure history is recorded
 FORCE_STATE_WRITE_INTERVAL = timedelta(minutes=5)
+
+
+def _activity_from_cleaning_status(
+    status: CleaningStatusMode,
+) -> VacuumActivity | None:
+    """Map a cleaning status to a vacuum activity, if it maps to one."""
+    if status in (CleaningStatusMode.CLEANING, CleaningStatusMode.STARTING):
+        return VacuumActivity.CLEANING
+    if status == CleaningStatusMode.STOPPED:
+        return VacuumActivity.PAUSED
+    return None
 
 
 def format_mac(mac: str) -> str:
@@ -242,17 +253,16 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         if dock_status is not None and dock_status.status == DockStatus.RETURNING:
             return VacuumActivity.RETURNING
 
-        # Check cleaning status BEFORE dock status
-        # The F1 reports DP 11 = DOCKED even while cleaning (no real dock),
-        # so we must check DP 0 first to avoid showing "docked" during cleaning
-        if cleaning_status is not None:
-            if cleaning_status.status in (
-                CleaningStatusMode.CLEANING,
-                CleaningStatusMode.STARTING,
-            ):
-                return VacuumActivity.CLEANING
-            if cleaning_status.status == CleaningStatusMode.STOPPED:
-                return VacuumActivity.PAUSED
+        # The F1 has no dock but still reports DP 11 = DOCKED while it is out
+        # skimming, so on that model the cleaning status has to win. DS20
+        # robots keep the original dock-first order, where a docked robot that
+        # still reports STOPPED must read as DOCKED rather than PAUSED.
+        is_f1 = self._coordinator.is_f1(self._idx)
+
+        if is_f1 and cleaning_status is not None:
+            activity = _activity_from_cleaning_status(cleaning_status.status)
+            if activity is not None:
+                return activity
 
         # Check if docked - use dock status, dock connection status, or battery charging state
         is_docked = False
@@ -263,23 +273,28 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         elif battery is not None:
             is_docked = battery.charge_state in (BatteryState.CHARGING, BatteryState.CHARGED)
 
+        if is_docked and not is_f1:
+            return VacuumActivity.DOCKED
+
+        if cleaning_status is not None:
+            activity = _activity_from_cleaning_status(cleaning_status.status)
+            if activity is not None:
+                return activity
+            # The F1 parks itself in standby (0x0f) rather than reporting a
+            # dedicated idle status, which pywybot surfaces as UNKNOWN.
+            if is_f1 and cleaning_status.status == CleaningStatusMode.UNKNOWN:
+                return VacuumActivity.IDLE
+
         if is_docked:
             return VacuumActivity.DOCKED
 
-        # F1-specific: 0x0f (15) = IDLE/STANDBY
-        if cleaning_status is not None and cleaning_status.status == CleaningStatusMode.UNKNOWN:
-            return VacuumActivity.IDLE if hasattr(VacuumActivity, 'IDLE') else None
-
         return None
-
-    # F1-specific cleaning modes (values 14-15, outside DS20's 0-6 range)
-    F1_CLEANING_MODES = {14: "Smart", 15: "Standard"}
 
     @property
     def fan_speed_list(self) -> list[str]:
         """Return supported cleaning modes."""
-        if self._data and self._data.device and self._data.device.device_type == "WYF1":
-            return ["Standard", "Smart"]
+        if self._coordinator.is_f1(self._idx):
+            return list(CleaningMode.F1_CLEANING_MODES.values())
         return CleaningMode.CLEANING_MODES
 
     @property
@@ -290,14 +305,12 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         fan_speed = self._data.get_dp(CleaningMode)
         if fan_speed is None or fan_speed.data is None:
             return None
-        mode_val = int(fan_speed.data, 16)
-        # F1 modes
-        if mode_val in self.F1_CLEANING_MODES:
-            return self.F1_CLEANING_MODES[mode_val]
-        # DS20 modes
-        if mode_val < len(CleaningMode.CLEANING_MODES):
-            return fan_speed.cleaning_mode
-        return None
+        mode = fan_speed.cleaning_mode
+        # pywybot returns "Unknown (n)" for values it cannot name; surface that
+        # as no reading rather than an entry absent from fan_speed_list.
+        if mode not in self.fan_speed_list:
+            return None
+        return mode
 
     @property
     def supported_features(self) -> VacuumEntityFeature:
@@ -307,8 +320,6 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
             | VacuumEntityFeature.RETURN_HOME
             | VacuumEntityFeature.START
             | VacuumEntityFeature.STOP
-            | VacuumEntityFeature.TURN_ON
-            | VacuumEntityFeature.TURN_OFF
         )
 
     async def _async_send_command(self, dp: GenericDP) -> None:
@@ -324,14 +335,17 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
         """Set the fan speed of the vacuum cleaner."""
-        # F1-specific modes
-        f1_mode_map = {"Standard": 15, "Smart": 14}
-        if fan_speed in f1_mode_map:
-            from wybot.dp_models import DP
-            dp = CleaningMode(data=DP(id=1, type=4, len=1, data=f"{f1_mode_map[fan_speed]:02x}"))
-            await self._async_send_command(dp)
-        else:
-            await self._async_send_command(CleaningMode(mode=fan_speed))
+        if fan_speed not in self.fan_speed_list:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_fan_speed",
+                translation_placeholders={
+                    "fan_speed": fan_speed,
+                    "fan_speed_list": ", ".join(self.fan_speed_list),
+                },
+            )
+        # pywybot's setter resolves both the DS20 and F1 mode names.
+        await self._async_send_command(CleaningMode(mode=fan_speed))
 
     async def async_stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""
@@ -343,18 +357,6 @@ class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
         """Start the vacuum cleaner."""
         await self._async_send_command(
             CleaningStatus(status=CleaningStatusMode.CLEANING)
-        )
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn on the vacuum cleaner (alias for start)."""
-        await self._async_send_command(
-            CleaningStatus(status=CleaningStatusMode.CLEANING)
-        )
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn off the vacuum cleaner (alias for stop)."""
-        await self._async_send_command(
-            CleaningStatus(status=CleaningStatusMode.STOPPED)
         )
 
     async def async_return_to_base(self, **kwargs: Any) -> None:

--- a/custom_components/wybot/wybot_coordinator.py
+++ b/custom_components/wybot/wybot_coordinator.py
@@ -12,7 +12,14 @@ from wybot.ble_client import WyBotBLEClient
 from wybot.dp_models import GenericDP
 from wybot.exceptions import WybotAuthError, WybotConnectionError
 from wybot.http_client import WyBotHTTPClient
-from wybot.models import Command, Device, Docker, Group
+from wybot.models import (
+    Command,
+    Device,
+    Docker,
+    Group,
+    MQTTMessage,
+    MQTTMessageKind,
+)
 from wybot.mqtt_client import WyBotMQTTClient
 
 from .bluetooth_adapter import HomeAssistantBluetoothAdapter
@@ -56,7 +63,7 @@ class WyBotCoordinator(DataUpdateCoordinator):
     _http_failure_count: int = 0
     _mqtt_failure_count: int = 0
     _last_status_query_time: float = 0.0
-    _online_devices: set[str] = set()
+    _online_devices: set[str]  # device ids currently reported online
     _initial_query_start_time: float = 0.0
     _ble_wake_enabled: bool = True
 
@@ -111,6 +118,9 @@ class WyBotCoordinator(DataUpdateCoordinator):
         self._last_ble_poll = {}
         self._data_source = {}
         self._ble_available = {}
+        # Was a class-level set(), so every coordinator shared one instance and
+        # online state leaked between config entries and across reloads.
+        self._online_devices = set()
 
         # Initialize BLE command tracking
         self._ble_command_failures = {}
@@ -568,145 +578,84 @@ class WyBotCoordinator(DataUpdateCoordinator):
                     device.docker.docker_id
                 )
 
-    def on_message(self, topic: str, data: dict[str, Any]) -> None:
-        """Handle a message from MQTT."""
-        data_updated = False
+    def _apply_online_status(self, deviceId: str, is_online: bool) -> None:
+        """Record a device's online status from a will message."""
+        group = self.get_group(deviceId)
+        if group is None:
+            return
+        if group.device.device_id == deviceId:
+            group.device.online = is_online
+        elif group.docker is not None and group.docker.docker_id == deviceId:
+            group.docker.online = is_online
+        self.data[group.id] = group
+        if is_online:
+            self._online_devices.add(deviceId)
+            _LOGGER.debug("Device %s came online, querying status", deviceId)
+            # on_message runs in the event loop (from the MQTT listen task) but
+            # is sync; schedule the async status query.
+            self.hass.async_create_task(
+                self.wybot_mqtt_client.ensure_device_sends_statuses(deviceId)
+            )
+        else:
+            self._online_devices.discard(deviceId)
 
-        _LOGGER.debug(
-            "MQTT on_message - Topic: %s, cmd: %s",
-            topic,
-            data.get("cmd") if isinstance(data, dict) else "N/A",
-        )
+    def _merge_reported_dps(self, deviceId: str, command: Command, source: str) -> None:
+        """Merge DPs reported for ``deviceId`` into whichever half of the group owns it."""
+        group = self.get_group(deviceId)
+        if group is None:
+            return
+        incoming_dps: dict[str, Any] = command.get_dps_as_keyed_dict()
+        if group.docker is not None and group.docker.docker_id == deviceId:
+            group.docker.dps = {**group.docker.dps, **incoming_dps}
+            _LOGGER.debug("Updated docker %s DPs from %s", deviceId, source)
+        elif group.device is not None:
+            group.device.dps = {**group.device.dps, **incoming_dps}
+            _LOGGER.debug("Updated device %s DPs from %s", deviceId, source)
+        self.data[group.id] = group
 
-        if topic.startswith("/will/"):
-            deviceId = topic[6:]
-            is_online = data.get("online") == "1"
+    def on_message(self, message: MQTTMessage) -> None:
+        """Handle a parsed MQTT message from pywybot.
+
+        pywybot owns the broker's topic layout and payload parsing, so this
+        only reacts to the semantic kind: an online/offline flag or reported
+        device DPs.
+        """
+        deviceId = message.device_id
+        if deviceId is None:
+            _LOGGER.debug("Ignoring MQTT message on %s", message.topic)
+            return
+
+        _LOGGER.debug("MQTT on_message - kind: %s, device: %s", message.kind, deviceId)
+
+        # Any message on a device topic proves the cloud path is alive.
+        self._record_mqtt_data_received(deviceId)
+
+        if message.kind is MQTTMessageKind.WILL:
+            if message.online is None:
+                _LOGGER.debug("Will message for %s carried no online flag", deviceId)
+                return
             _LOGGER.debug(
                 "Device %s online status: %s",
                 deviceId,
-                "online" if is_online else "offline",
+                "online" if message.online else "offline",
             )
-            # Record that we received MQTT data from this device
-            self._record_mqtt_data_received(deviceId)
-            # Update device online status
-            group = self.get_group(deviceId)
-            if group is not None:
-                if group.device.device_id == deviceId:
-                    group.device.online = is_online
-                elif group.docker is not None and group.docker.docker_id == deviceId:
-                    group.docker.online = is_online
-                self.data[group.id] = group
-                # Track online devices
-                if is_online:
-                    self._online_devices.add(deviceId)
-                    _LOGGER.debug("Device %s came online, querying status", deviceId)
-                    # on_message runs in the event loop (from the MQTT listen
-                    # task) but is sync; schedule the async status query.
-                    self.hass.async_create_task(
-                        self.wybot_mqtt_client.ensure_device_sends_statuses(deviceId)
-                    )
-                else:
-                    self._online_devices.discard(deviceId)
-            # Will messages indicate device availability changes, always trigger update
-            data_updated = True
-
-        if topic.startswith("/device/DATA/send_transparent_data/"):
-            deviceId = topic[35:]
-            # Record that we received MQTT data from this device
-            self._record_mqtt_data_received(deviceId)
-            _LOGGER.debug(
-                "Processing send_transparent_data for device %s",
-                deviceId,
-            )
-            try:
-                command_response = Command(**data)
-                _LOGGER.debug(
-                    "Parsed Command: cmd=%s, dp_count=%s",
-                    command_response.cmd,
-                    len(command_response.dp),
-                )
-            except Exception as err:
-                _LOGGER.error("Failed to parse Command from data: %s, error: %s", data, err)
-                command_response = None
-
-            if command_response is None:
-                return
-
-            group = self.get_group(deviceId)
-            incoming_dps: dict[str, Any] = command_response.get_dps_as_keyed_dict()
-            if (
-                group is not None
-                and group.docker is not None
-                and group.docker.docker_id == deviceId
-            ):
-                group.docker.dps = {
-                    **group.docker.dps,
-                    **incoming_dps,
-                }
-                _LOGGER.debug(
-                    "Updated docker %s DPs from send_transparent_data",
-                    deviceId,
-                )
-                data_updated = True
-            elif group is not None and group.device is not None:
-                group.device.dps = {
-                    **group.device.dps,
-                    **incoming_dps,
-                }
-                _LOGGER.debug(
-                    "Updated device %s DPs from send_transparent_data",
-                    deviceId,
-                )
-                data_updated = True
-            if group is not None:
-                self.data[group.id] = group
-
-        if topic.startswith("/device/DATA/recv_transparent_query_data/"):
-            deviceId = topic[41:]
-            # Record that we received MQTT data from this device
-            self._record_mqtt_data_received(deviceId)
-            command_response = Command(**data)
-            _LOGGER.debug("Query CMD ---- %s ----- %s", deviceId, command_response)
-
-        if topic.startswith("/device/DATA/recv_transparent_cmd_data/"):
-            deviceId = topic[39:]
-            # Record that we received MQTT data from this device
-            self._record_mqtt_data_received(deviceId)
-            command_response = Command(**data)
-            _LOGGER.debug("SEND CMD ---- %s ----- %s", deviceId, command_response)
-
-            # Update device DPs with the received data (cmd=4 contains actual values)
-            group = self.get_group(deviceId)
-            if group is not None:
-                cmd_dps: dict[str, Any] = command_response.get_dps_as_keyed_dict()
-                if (
-                    group.docker is not None
-                    and group.docker.docker_id == deviceId
-                ):
-                    group.docker.dps = {
-                        **group.docker.dps,
-                        **cmd_dps,
-                    }
-                    _LOGGER.debug(
-                        "Updated docker %s DPs from cmd_data",
-                        deviceId,
-                    )
-                elif group.device is not None:
-                    group.device.dps = {
-                        **group.device.dps,
-                        **cmd_dps,
-                    }
-                    _LOGGER.debug(
-                        "Updated device %s DPs from cmd_data",
-                        deviceId,
-                    )
-                self.data[group.id] = group
-                data_updated = True
-
-        # Always trigger update when we receive MQTT messages to ensure state is written
-        # This ensures history is recorded even if computed state values don't change
-        if data_updated or topic.startswith("/device/DATA/"):
+            self._apply_online_status(deviceId, message.online)
+            # Availability changed, so always publish.
             self.hass.add_job(self.async_set_updated_data, self.data)
+            return
+
+        if message.command is not None:
+            if message.kind is MQTTMessageKind.DATA_REPORT:
+                self._merge_reported_dps(deviceId, message.command, "send_transparent_data")
+            elif message.kind is MQTTMessageKind.COMMAND_RESPONSE:
+                # cmd=4 responses carry the actual values.
+                self._merge_reported_dps(deviceId, message.command, "cmd_data")
+            elif message.kind is MQTTMessageKind.QUERY_RESPONSE:
+                _LOGGER.debug("Query CMD ---- %s ----- %s", deviceId, message.command)
+
+        # Publish on every device message, even when no DP changed, so history
+        # keeps being recorded.
+        self.hass.add_job(self.async_set_updated_data, self.data)
 
     def get_device_or_docker(self, deviceId: str) -> Device | Docker | None:
         """Loops through the self.data and find the device matching the deviceId"""

--- a/custom_components/wybot/wybot_coordinator.py
+++ b/custom_components/wybot/wybot_coordinator.py
@@ -20,6 +20,7 @@ from .const import (
     BLE_MAX_CONSECUTIVE_FAILURES,
     CONF_WIFI_PASSWORD,
     CONF_WIFI_SSID,
+    F1_DEVICE_TYPE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -987,3 +988,14 @@ class WyBotCoordinator(DataUpdateCoordinator):
         Right now we only support WyBot vacuums so we return everything, but this could be expanded
         """
         return [deviceId for [deviceId, device] in self.data.items()]
+
+    def is_f1(self, idx: str) -> bool:
+        """Return whether the group at ``idx`` is an F1 skimmer.
+
+        Platforms use this to skip creating F1-only entities on DS20 robots,
+        which would otherwise show up permanently unknown.
+        """
+        group = self.data.get(idx) if self.data else None
+        if group is None or group.device is None:
+            return False
+        return group.device.device_type == F1_DEVICE_TYPE

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,7 @@ pytest-cov
 
 # The WyBot client library (also declared in manifest.json requirements).
 # Pulls in aiohttp, aiomqtt, bleak, bleak-retry-connector, and pydantic.
-pywybot==1.0.0
+pywybot==1.3.0
 
 # Transitive requirements pulled in by `homeassistant.components.bluetooth`
 # (and the usb component it imports) when the wybot package is loaded.

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -45,7 +45,7 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     entry.runtime_data = coord
     added: list = []
     await async_setup_entry(hass, entry, lambda e: added.extend(e))
-    assert len(added) == 2
+    assert len(added) == 3
 
 
 async def test_robot_charging_on(hass: HomeAssistant) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -26,6 +26,7 @@ from custom_components.wybot.wybot_coordinator import (
 from wybot import WybotAuthError
 from wybot.dp_models import DP, CleaningStatus
 from wybot.models import Group
+from wybot.mqtt_client import WyBotMQTTClient
 
 DEVICE_ID = "dev123"
 DOCKER_ID = "dock456"
@@ -600,10 +601,22 @@ def _cmd(dp_id: int = 0, data: str = "03") -> dict:
     return {"cmd": 5, "ts": 0, "dp": [{"id": dp_id, "type": 4, "len": 1, "data": data}]}
 
 
+def _msg(topic: str, payload):
+    """Parse a raw topic and payload the way the MQTT receive loop does.
+
+    Going through pywybot's own parser rather than hand-building an
+    ``MQTTMessage`` keeps these tests honest about the library contract: when
+    the callback signature changed in pywybot 1.2.0, tests that called
+    ``on_message(topic, data)`` directly kept passing while the real path was
+    broken.
+    """
+    return WyBotMQTTClient(lambda _message: None)._parse_message(topic, payload)
+
+
 async def test_on_message_will_online(hass: HomeAssistant) -> None:
     coord = make_coordinator(hass)
     coord.data = {GROUP_ID: make_group()}
-    coord.on_message(f"/will/{DEVICE_ID}", {"online": "1"})
+    coord.on_message(_msg(f"/will/{DEVICE_ID}", {"online": "1"}))
     assert DEVICE_ID in coord._online_devices
     assert coord.data[GROUP_ID].device.online is True
     coord.wybot_mqtt_client.ensure_device_sends_statuses.assert_called_with(DEVICE_ID)
@@ -615,7 +628,7 @@ async def test_on_message_will_offline_docker(hass: HomeAssistant) -> None:
     group = make_group()
     coord.data = {GROUP_ID: group}
     coord._online_devices.add(DOCKER_ID)
-    coord.on_message(f"/will/{DOCKER_ID}", {"online": "0"})
+    coord.on_message(_msg(f"/will/{DOCKER_ID}", {"online": "0"}))
     assert DOCKER_ID not in coord._online_devices
     assert coord.data[GROUP_ID].docker.online is False
     await hass.async_block_till_done()
@@ -625,7 +638,34 @@ async def test_on_message_will_unknown_device(hass: HomeAssistant) -> None:
     coord = make_coordinator(hass)
     coord.data = {GROUP_ID: make_group()}
     # unknown device id -> group is None, but data_updated still True
-    coord.on_message("/will/unknown", {"online": "1"})
+    coord.on_message(_msg("/will/unknown", {"online": "1"}))
+    await hass.async_block_till_done()
+
+
+async def test_on_message_unrelated_topic_ignored(hass: HomeAssistant) -> None:
+    """A topic pywybot cannot attribute to a device carries no device id."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_msg("/ota/progress", {"pct": 10}))
+    # Nothing to attribute it to, so no device is marked online.
+    assert coord._online_devices == set()
+    await hass.async_block_till_done()
+
+
+async def test_on_message_will_without_online_flag(hass: HomeAssistant) -> None:
+    """A non-JSON will payload leaves online unset; treat it as no information."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_msg(f"/will/{DEVICE_ID}", b"not-json"))
+    assert DEVICE_ID not in coord._online_devices
+    await hass.async_block_till_done()
+
+
+async def test_on_message_dps_for_unknown_device(hass: HomeAssistant) -> None:
+    """DPs for a device absent from coordinator data are dropped, not crashed on."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_msg("/device/DATA/send_transparent_data/nope", _cmd(11, "00")))
     await hass.async_block_till_done()
 
 
@@ -633,9 +673,7 @@ async def test_on_message_send_transparent_data_docker(hass: HomeAssistant) -> N
     coord = make_coordinator(hass)
     group = make_group()
     coord.data = {GROUP_ID: group}
-    coord.on_message(
-        f"/device/DATA/send_transparent_data/{DOCKER_ID}", _cmd(11, "00")
-    )
+    coord.on_message(_msg(f"/device/DATA/send_transparent_data/{DOCKER_ID}", _cmd(11, "00")))
     assert "11" in coord.data[GROUP_ID].docker.dps
     await hass.async_block_till_done()
 
@@ -644,9 +682,7 @@ async def test_on_message_send_transparent_data_device(hass: HomeAssistant) -> N
     coord = make_coordinator(hass)
     group = make_group(with_docker=False)
     coord.data = {GROUP_ID: group}
-    coord.on_message(
-        f"/device/DATA/send_transparent_data/{DEVICE_ID}", _cmd(1, "01")
-    )
+    coord.on_message(_msg(f"/device/DATA/send_transparent_data/{DEVICE_ID}", _cmd(1, "01")))
     assert "1" in coord.data[GROUP_ID].device.dps
     await hass.async_block_till_done()
 
@@ -655,18 +691,14 @@ async def test_on_message_send_transparent_data_bad(hass: HomeAssistant) -> None
     coord = make_coordinator(hass)
     coord.data = {GROUP_ID: make_group()}
     # invalid Command payload -> parse fails -> returns early
-    coord.on_message(
-        f"/device/DATA/send_transparent_data/{DOCKER_ID}", {"garbage": True}
-    )
+    coord.on_message(_msg(f"/device/DATA/send_transparent_data/{DOCKER_ID}", {"garbage": True}))
     await hass.async_block_till_done()
 
 
 async def test_on_message_recv_query_data(hass: HomeAssistant) -> None:
     coord = make_coordinator(hass)
     coord.data = {GROUP_ID: make_group()}
-    coord.on_message(
-        f"/device/DATA/recv_transparent_query_data/{DOCKER_ID}", _cmd()
-    )
+    coord.on_message(_msg(f"/device/DATA/recv_transparent_query_data/{DOCKER_ID}", _cmd()))
     await hass.async_block_till_done()
 
 
@@ -674,9 +706,7 @@ async def test_on_message_recv_cmd_data_docker(hass: HomeAssistant) -> None:
     coord = make_coordinator(hass)
     group = make_group()
     coord.data = {GROUP_ID: group}
-    coord.on_message(
-        f"/device/DATA/recv_transparent_cmd_data/{DOCKER_ID}", _cmd(11, "01")
-    )
+    coord.on_message(_msg(f"/device/DATA/recv_transparent_cmd_data/{DOCKER_ID}", _cmd(11, "01")))
     assert "11" in coord.data[GROUP_ID].docker.dps
     await hass.async_block_till_done()
 
@@ -685,9 +715,7 @@ async def test_on_message_recv_cmd_data_device(hass: HomeAssistant) -> None:
     coord = make_coordinator(hass)
     group = make_group(with_docker=False)
     coord.data = {GROUP_ID: group}
-    coord.on_message(
-        f"/device/DATA/recv_transparent_cmd_data/{DEVICE_ID}", _cmd(1, "01")
-    )
+    coord.on_message(_msg(f"/device/DATA/recv_transparent_cmd_data/{DEVICE_ID}", _cmd(1, "01")))
     assert "1" in coord.data[GROUP_ID].device.dps
     await hass.async_block_till_done()
 

--- a/tests/test_f1.py
+++ b/tests/test_f1.py
@@ -1,0 +1,727 @@
+"""Tests for F1 skimmer support across the WyBot platforms.
+
+The F1 differs from the DS20 robots in ways that are easy to regress: it has no
+dock, encodes DP 50 with an extra byte, uses cleaning modes outside the DS20
+range, and reports itself docked while it is actually out skimming. These tests
+pin that behaviour down and, just as importantly, assert that DS20 setups are
+left alone.
+"""
+
+from __future__ import annotations
+
+from homeassistant.components.vacuum import VacuumActivity, VacuumEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+import pytest
+
+from custom_components.wybot.binary_sensor import (
+    WyBotDockChargingBinarySensor,
+    WyBotFullyChargedBinarySensor,
+)
+from custom_components.wybot.const import F1_DEVICE_TYPE
+from custom_components.wybot.sensor import (
+    WyBotF1CleaningModeSensor,
+    WyBotF1CycleRuntimeSensor,
+    WyBotF1HeavyDirtSensor,
+    WyBotF1InWaterSensor,
+    WyBotF1MotorPWMSensor,
+    WyBotF1PhSensor,
+    WyBotF1RuntimeSensor,
+    WyBotF1SolarBatterySensor,
+    WyBotF1SonarSensor,
+    WyBotF1TotalEnergySensor,
+    WyBotRobotBatterySensor,
+    WyBotSolarDockBatterySensor,
+)
+from custom_components.wybot.sensor import async_setup_entry as sensor_setup_entry
+from custom_components.wybot.switch import WyBotF1AutoRunSwitch
+from custom_components.wybot.switch import format_mac as switch_format_mac
+from custom_components.wybot.switch import async_setup_entry as switch_setup_entry
+from custom_components.wybot.vacuum import WyBotVacuum
+from wybot.dp_models import (
+    DP,
+    AutoRunMode,
+    Battery,
+    CleaningMode,
+    CleaningStatus,
+    CleaningStatusMode,
+    Dock,
+    DockStatus,
+    GenericDP,
+    HeavyDirtMode,
+    PhData,
+)
+
+from wybot_platform_helpers import add_entity, dp, make_coordinator, make_group
+
+IDX = "grp1"
+
+# DP 50 on the F1 is [charge_state][solar %][robot %]; "016302" is charging,
+# 99% solar, 2% robot. The DS20 sends two bytes and no solar byte at all.
+F1_BATTERY = "016302"
+DS20_BATTERY = "0132"
+
+
+def _f1_dps(battery=F1_BATTERY, **extra):
+    dps = {"50": dp(Battery, id=50, type=0, len=3, data=battery)}
+    dps.update(extra)
+    return dps
+
+
+def _f1_coord(hass, device_dps=None, with_docker=False):
+    """Build a coordinator holding a single F1 group."""
+    group = make_group(
+        device_dps=device_dps if device_dps is not None else _f1_dps(),
+        with_docker=with_docker,
+        device_type=F1_DEVICE_TYPE,
+    )
+    coord, entry = make_coordinator(hass, {IDX: group})
+    return coord, entry, group
+
+
+def _ds20_coord(hass, device_dps=None):
+    group = make_group(
+        device_dps=device_dps
+        if device_dps is not None
+        else {"50": dp(Battery, id=50, type=0, len=2, data=DS20_BATTERY)},
+    )
+    coord, entry = make_coordinator(hass, {IDX: group})
+    return coord, entry, group
+
+
+async def test_coordinator_identifies_f1(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    assert coord.is_f1(IDX) is True
+
+
+async def test_coordinator_does_not_identify_ds20_as_f1(hass: HomeAssistant) -> None:
+    coord, _, _ = _ds20_coord(hass)
+    assert coord.is_f1(IDX) is False
+
+
+async def test_coordinator_is_f1_unknown_group(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    assert coord.is_f1("nope") is False
+
+
+# ---------------------------------------------------------------------------
+# Entity creation is gated on the device type
+# ---------------------------------------------------------------------------
+
+
+async def test_f1_sensors_created_for_f1(hass: HomeAssistant) -> None:
+    coord, entry, _ = _f1_coord(hass)
+    entry.runtime_data = coord
+    added: list = []
+    await sensor_setup_entry(hass, entry, lambda e: added.extend(e))
+    names = {type(e).__name__ for e in added}
+    assert "WyBotF1PhSensor" in names
+    assert "WyBotF1SolarBatterySensor" in names
+
+
+async def test_f1_sensors_not_created_for_ds20(hass: HomeAssistant) -> None:
+    """A DS20 owner must not gain a screenful of permanently-unknown entities."""
+    coord, entry, _ = _ds20_coord(hass)
+    entry.runtime_data = coord
+    added: list = []
+    await sensor_setup_entry(hass, entry, lambda e: added.extend(e))
+    assert not [e for e in added if type(e).__name__.startswith("WyBotF1")]
+
+
+async def test_auto_run_switch_created_for_f1(hass: HomeAssistant) -> None:
+    coord, entry, _ = _f1_coord(hass)
+    entry.runtime_data = coord
+    added: list = []
+    await switch_setup_entry(hass, entry, lambda e: added.extend(e))
+    assert len(added) == 1
+    assert isinstance(added[0], WyBotF1AutoRunSwitch)
+
+
+async def test_auto_run_switch_not_created_for_ds20(hass: HomeAssistant) -> None:
+    coord, entry, _ = _ds20_coord(hass)
+    entry.runtime_data = coord
+    added: list = []
+    await switch_setup_entry(hass, entry, lambda e: added.extend(e))
+    assert added == []
+
+
+# ---------------------------------------------------------------------------
+# Battery handling
+# ---------------------------------------------------------------------------
+
+
+async def test_f1_solar_battery_reads_middle_byte(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1SolarBatterySensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == 99
+    assert ent.unique_id == "wybot_grp1_f1_solar_battery"
+    assert ent.extra_state_attributes == {"charge_state": "CHARGING"}
+
+
+async def test_f1_solar_battery_no_data(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass, device_dps={})
+    ent = WyBotF1SolarBatterySensor(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+    assert ent.extra_state_attributes == {}
+    ent._data = None
+    assert ent.native_value is None
+    assert ent.extra_state_attributes == {}
+
+
+async def test_robot_battery_unknown_when_f1_unplugged(hass: HomeAssistant) -> None:
+    """The F1 freezes its robot byte on solar, so it must read as unknown."""
+    coord, _, _ = _f1_coord(hass, device_dps=_f1_dps(battery="000e01"))
+    ent = WyBotRobotBatterySensor(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+
+
+async def test_robot_battery_reported_when_f1_plugged_in(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotRobotBatterySensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == 2
+
+
+async def test_robot_battery_unaffected_for_ds20(hass: HomeAssistant) -> None:
+    """The DS20's two-byte payload has no staleness problem."""
+    coord, _, _ = _ds20_coord(hass)
+    ent = WyBotRobotBatterySensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == 50
+
+
+async def test_solar_dock_battery_falls_back_to_f1_battery(
+    hass: HomeAssistant,
+) -> None:
+    """With no DS20 dock DP, the dock battery sensor uses the F1 solar byte."""
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotSolarDockBatterySensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == 99
+
+
+async def test_fully_charged_binary_sensor(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass, device_dps=_f1_dps(battery="026402"))
+    ent = WyBotFullyChargedBinarySensor(idx=IDX, coordinator=coord)
+    assert ent.is_on is True
+    assert ent.unique_id == "wybot_grp1_fully_charged"
+    assert ent.name == "Fully charged"
+    attrs = ent.extra_state_attributes
+    assert attrs["charge_state"] == "CHARGED"
+    assert attrs["solar_battery"] == 100
+
+
+async def test_fully_charged_off_while_charging(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotFullyChargedBinarySensor(idx=IDX, coordinator=coord)
+    assert ent.is_on is False
+
+
+async def test_fully_charged_no_data(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass, device_dps={})
+    ent = WyBotFullyChargedBinarySensor(idx=IDX, coordinator=coord)
+    assert ent.is_on is None
+    assert ent.extra_state_attributes == {}
+    ent._data = None
+    assert ent.is_on is None
+    assert ent.extra_state_attributes == {}
+
+
+async def test_fully_charged_ds20_two_byte_omits_solar(hass: HomeAssistant) -> None:
+    coord, _, _ = _ds20_coord(
+        hass, device_dps={"50": dp(Battery, id=50, type=0, len=2, data="0264")}
+    )
+    ent = WyBotFullyChargedBinarySensor(idx=IDX, coordinator=coord)
+    assert ent.is_on is True
+    assert "solar_battery" not in ent.extra_state_attributes
+
+
+async def test_dock_charging_falls_back_to_f1_charge_state(
+    hass: HomeAssistant,
+) -> None:
+    """The F1 has no DP 222, so charging comes from the battery charge state."""
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotDockChargingBinarySensor(idx=IDX, coordinator=coord)
+    assert ent.is_on is True
+
+
+async def test_dock_charging_f1_not_charging(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass, device_dps=_f1_dps(battery="000e01"))
+    ent = WyBotDockChargingBinarySensor(idx=IDX, coordinator=coord)
+    assert ent.is_on is False
+
+
+async def test_dock_charging_none_without_any_dp(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass, device_dps={})
+    ent = WyBotDockChargingBinarySensor(idx=IDX, coordinator=coord)
+    assert ent.is_on is None
+
+
+# ---------------------------------------------------------------------------
+# Cleaning mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [("0e", "Smart"), ("0f", "Standard")],
+)
+async def test_f1_cleaning_mode_sensor(
+    hass: HomeAssistant, data: str, expected: str
+) -> None:
+    coord, _, _ = _f1_coord(
+        hass, device_dps=_f1_dps(**{"1": dp(CleaningMode, id=1, type=4, len=1, data=data)})
+    )
+    ent = WyBotF1CleaningModeSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == expected
+
+
+async def test_f1_cleaning_mode_sensor_no_dp(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1CleaningModeSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+    ent._data = None
+    assert ent.native_value is None
+
+
+async def test_f1_fan_speed_list(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.fan_speed_list == ["Smart", "Standard"]
+
+
+async def test_ds20_fan_speed_list_unchanged(hass: HomeAssistant) -> None:
+    coord, _, _ = _ds20_coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.fan_speed_list == CleaningMode.CLEANING_MODES
+
+
+async def test_f1_fan_speed(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(
+        hass, device_dps=_f1_dps(**{"1": dp(CleaningMode, id=1, type=4, len=1, data="0e")})
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.fan_speed == "Smart"
+
+
+async def test_fan_speed_none_for_mode_outside_list(hass: HomeAssistant) -> None:
+    """A DS20 mode reported by an F1 is not a valid F1 fan speed."""
+    coord, _, _ = _f1_coord(
+        hass, device_dps=_f1_dps(**{"1": dp(CleaningMode, id=1, type=4, len=1, data="03")})
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.fan_speed is None
+
+
+async def test_set_fan_speed_rejects_unsupported_mode(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    with pytest.raises(ServiceValidationError):
+        await ent.async_set_fan_speed("Turbo Floor")
+
+
+# ---------------------------------------------------------------------------
+# Vacuum activity ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_f1_cleaning_wins_over_phantom_dock(hass: HomeAssistant) -> None:
+    """The F1 claims DP 11 = DOCKED while skimming; cleaning must win."""
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(
+            **{
+                "0": dp(CleaningStatus, id=0, type=4, len=1, data="03"),
+                "11": dp(Dock, id=11, type=4, len=1, data="00"),
+            }
+        ),
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.CLEANING
+
+
+async def test_ds20_docked_wins_over_stopped(hass: HomeAssistant) -> None:
+    """A docked DS20 reporting STOPPED must read DOCKED, not PAUSED."""
+    coord, _, _ = _ds20_coord(
+        hass,
+        device_dps={
+            "50": dp(Battery, id=50, type=0, len=2, data=DS20_BATTERY),
+            "0": dp(CleaningStatus, id=0, type=4, len=1, data="01"),
+            "11": dp(Dock, id=11, type=4, len=1, data="00"),
+        },
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.DOCKED
+
+
+async def test_f1_standby_reads_idle(hass: HomeAssistant) -> None:
+    """DP 0 = 0x0f is the F1's standby; pywybot surfaces it as UNKNOWN."""
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(**{"0": dp(CleaningStatus, id=0, type=4, len=1, data="0f")}),
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.IDLE
+
+
+async def test_ds20_unknown_status_is_not_idle(hass: HomeAssistant) -> None:
+    """Only the F1 maps an unknown cleaning status to idle."""
+    coord, _, _ = _ds20_coord(
+        hass,
+        device_dps={"0": dp(CleaningStatus, id=0, type=4, len=1, data="0f")},
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity is None
+
+
+async def test_f1_returning_still_wins(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(**{"0": dp(CleaningStatus, id=0, type=4, len=1, data="04")}),
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.RETURNING
+
+
+async def test_f1_docked_when_charging_and_idle(hass: HomeAssistant) -> None:
+    """A charging F1 with no cleaning DP still falls through to docked."""
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.DOCKED
+
+
+async def test_vacuum_does_not_advertise_turn_on_off(hass: HomeAssistant) -> None:
+    """StateVacuumEntity does not support TURN_ON/TURN_OFF."""
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert not ent.supported_features & VacuumEntityFeature.TURN_ON
+    assert not ent.supported_features & VacuumEntityFeature.TURN_OFF
+
+
+# ---------------------------------------------------------------------------
+# Auto-run switch
+# ---------------------------------------------------------------------------
+
+
+async def test_auto_run_switch_state(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(
+        hass, device_dps=_f1_dps(**{"207": dp(AutoRunMode, id=207, type=4, len=1, data="01")})
+    )
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    assert ent.is_on is True
+    assert ent.unique_id == "wybot_grp1_f1_auto_run_switch"
+    assert ent.name == "Auto run"
+
+
+async def test_auto_run_switch_off(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(
+        hass, device_dps=_f1_dps(**{"207": dp(AutoRunMode, id=207, type=4, len=1, data="00")})
+    )
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    assert ent.is_on is False
+
+
+async def test_auto_run_switch_unknown_without_dp(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    assert ent.is_on is None
+    ent._data = None
+    assert ent.is_on is None
+
+
+@pytest.mark.parametrize(("turn_on", "expected"), [(True, "01"), (False, "00")])
+async def test_auto_run_switch_sends_dp_207(
+    hass: HomeAssistant, turn_on: bool, expected: str
+) -> None:
+    coord, _, group = _f1_coord(hass)
+    sent: list[GenericDP] = []
+
+    async def _send(target, command):
+        sent.append(command)
+        return True
+
+    coord.async_send_command = _send
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    if turn_on:
+        await ent.async_turn_on()
+    else:
+        await ent.async_turn_off()
+    assert len(sent) == 1
+    assert sent[0].id == 207
+    assert sent[0].data == expected
+
+
+async def test_auto_run_switch_raises_when_send_fails(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+
+    async def _send(target, command):
+        return False
+
+    coord.async_send_command = _send
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    with pytest.raises(HomeAssistantError):
+        await ent.async_turn_on()
+
+
+async def test_auto_run_switch_raises_without_data(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    ent._data = None
+    with pytest.raises(HomeAssistantError):
+        await ent.async_turn_on()
+
+
+# ---------------------------------------------------------------------------
+# Raw-DP sensors
+# ---------------------------------------------------------------------------
+
+
+async def test_ph_sensor(hass: HomeAssistant) -> None:
+    """pH and electrode temperature are little-endian, scaled by 100 and 10."""
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(
+            **{"142": dp(PhData, id=142, type=2, len=4, data="d0021901")}
+        ),
+    )
+    ent = WyBotF1PhSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == 7.2
+    assert ent.extra_state_attributes == {"electrode_temperature": 28.1}
+
+
+async def test_ph_sensor_no_dp(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1PhSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+    assert ent.extra_state_attributes == {}
+    ent._data = None
+    assert ent.native_value is None
+    assert ent.extra_state_attributes == {}
+
+
+async def test_heavy_dirt_sensor(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(
+            **{"145": dp(HeavyDirtMode, id=145, type=4, len=1, data="01")}
+        ),
+    )
+    ent = WyBotF1HeavyDirtSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == "Enabled"
+
+
+async def test_heavy_dirt_sensor_disabled(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(
+            **{"145": dp(HeavyDirtMode, id=145, type=4, len=1, data="00")}
+        ),
+    )
+    ent = WyBotF1HeavyDirtSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == "Disabled"
+
+
+async def test_heavy_dirt_sensor_no_dp(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1HeavyDirtSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+    ent._data = None
+    assert ent.native_value is None
+
+
+@pytest.mark.parametrize(
+    ("entity_cls", "dp_id", "data", "expected"),
+    [
+        (WyBotF1InWaterSensor, "212", "01", "Yes"),
+        (WyBotF1InWaterSensor, "212", "00", "No"),
+        (WyBotF1SonarSensor, "209", "01", "Active"),
+        (WyBotF1SonarSensor, "209", "00", "Inactive"),
+    ],
+)
+async def test_boolean_raw_dp_sensors(
+    hass: HomeAssistant, entity_cls, dp_id: str, data: str, expected: str
+) -> None:
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(**{dp_id: DP(id=int(dp_id), type=4, len=1, data=data)}),
+    )
+    ent = entity_cls(idx=IDX, coordinator=coord)
+    assert ent.native_value == expected
+
+
+@pytest.mark.parametrize(
+    "entity_cls", [WyBotF1InWaterSensor, WyBotF1SonarSensor]
+)
+async def test_boolean_raw_dp_sensors_no_dp(hass: HomeAssistant, entity_cls) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = entity_cls(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+    ent._data = None
+    assert ent.native_value is None
+
+
+@pytest.mark.parametrize(
+    ("entity_cls", "dp_id", "expected"),
+    [
+        (WyBotF1RuntimeSensor, "25", 1000),
+        (WyBotF1CycleRuntimeSensor, "55", 1000),
+        (WyBotF1TotalEnergySensor, "34", 1000),
+        (WyBotF1MotorPWMSensor, "81", 1000),
+    ],
+)
+async def test_le_raw_dp_sensors(
+    hass: HomeAssistant, entity_cls, dp_id: str, expected: int
+) -> None:
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(
+            **{dp_id: DP(id=int(dp_id), type=2, len=4, data="e8030000")}
+        ),
+    )
+    ent = entity_cls(idx=IDX, coordinator=coord)
+    assert ent.native_value == expected
+
+
+@pytest.mark.parametrize(
+    "entity_cls",
+    [
+        WyBotF1RuntimeSensor,
+        WyBotF1CycleRuntimeSensor,
+        WyBotF1TotalEnergySensor,
+        WyBotF1MotorPWMSensor,
+    ],
+)
+async def test_le_raw_dp_sensors_absent(hass: HomeAssistant, entity_cls) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = entity_cls(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+    ent._data = None
+    assert ent.native_value is None
+
+
+async def test_runtime_sensors_fall_back_to_alternate_dp(
+    hass: HomeAssistant,
+) -> None:
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(
+            **{"111": DP(id=111, type=2, len=4, data="e8030000")}
+        ),
+    )
+    assert WyBotF1RuntimeSensor(idx=IDX, coordinator=coord).native_value == 1000
+
+    coord, _, _ = _f1_coord(
+        hass,
+        device_dps=_f1_dps(
+            **{"129": DP(id=129, type=2, len=4, data="e8030000")}
+        ),
+    )
+    assert WyBotF1CycleRuntimeSensor(idx=IDX, coordinator=coord).native_value == 1000
+
+
+async def test_le_raw_dp_sensor_ignores_malformed_payload(
+    hass: HomeAssistant,
+) -> None:
+    coord, _, _ = _f1_coord(
+        hass, device_dps=_f1_dps(**{"25": DP(id=25, type=2, len=4, data="zzzz")})
+    )
+    ent = WyBotF1RuntimeSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value is None
+
+
+async def test_raw_dp_read_from_dock_when_absent_on_device(
+    hass: HomeAssistant,
+) -> None:
+    """DS20-style setups keep working: DPs may live on the dock instead."""
+    group = make_group(
+        device_dps={},
+        docker_dps={"25": DP(id=25, type=2, len=4, data="e8030000")},
+        device_type=F1_DEVICE_TYPE,
+    )
+    coord, _ = make_coordinator(hass, {IDX: group})
+    ent = WyBotF1RuntimeSensor(idx=IDX, coordinator=coord)
+    assert ent.native_value == 1000
+
+
+# ---------------------------------------------------------------------------
+# Switch platform plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_switch_format_mac() -> None:
+    assert switch_format_mac("CCBA97932A96") == "CC:BA:97:93:2A:96"
+    assert switch_format_mac("cc-ba-97-93-2a-96") == "CC:BA:97:93:2A:96"
+
+
+async def test_switch_setup_skips_already_known_devices(hass: HomeAssistant) -> None:
+    """The listener re-runs on every refresh but must not duplicate entities."""
+    coord, entry, _ = _f1_coord(hass)
+    entry.runtime_data = coord
+    added: list = []
+    await switch_setup_entry(hass, entry, lambda e: added.extend(e))
+    assert len(added) == 1
+    coord.async_update_listeners()
+    assert len(added) == 1
+
+
+async def test_switch_device_info(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    info = ent.device_info
+    assert info["identifiers"] == {("wybot", "grp1")}
+    assert info["name"] == "My Pool"
+    assert info["model"] == F1_DEVICE_TYPE
+    assert ("bluetooth", "CC:BA:97:93:2A:96") in info["connections"]
+    # The F1 has no dock, so nothing to hang the device off.
+    assert info["via_device"] is None
+
+
+async def test_switch_device_info_via_dock(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass, with_docker=True)
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    assert ent.device_info["via_device"] == ("wybot", "grp1_dock")
+
+
+async def test_switch_device_info_falls_back_through_names(
+    hass: HomeAssistant,
+) -> None:
+    coord, _, group = _f1_coord(hass)
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+
+    group.name = None
+    assert ent.device_info["name"] == "Robot"
+
+    group.device.device_name = None
+    assert ent.device_info["name"] == F1_DEVICE_TYPE
+
+    ent._data = None
+    assert ent.device_info["name"] == "Unknown"
+    assert ent.device_info["model"] == "Unknown"
+
+
+async def test_switch_availability(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord)
+    assert ent.available is True
+
+    ent._data = None
+    assert ent.available is False
+
+    ent._data = coord.data[IDX]
+    coord.data = {}
+    assert ent.available is False
+
+    coord._connection_available = False
+    assert ent.available is False
+
+
+async def test_switch_handles_coordinator_update(hass: HomeAssistant) -> None:
+    coord, _, _ = _f1_coord(hass)
+    ent = await add_entity(hass, WyBotF1AutoRunSwitch(idx=IDX, coordinator=coord), "switch")
+    updated = make_group(
+        device_dps=_f1_dps(
+            **{"207": dp(AutoRunMode, id=207, type=4, len=1, data="01")}
+        ),
+        with_docker=False,
+        device_type=F1_DEVICE_TYPE,
+    )
+    coord.data = {IDX: updated}
+    ent._handle_coordinator_update()
+    assert ent.is_on is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,7 +14,7 @@ from custom_components.wybot.sensor import (
     WyBotLastMQTTCommunicationSensor,
     WyBotRobotBatterySensor,
     WyBotSolarDockBatterySensor,
-    WyBotSolarEnergySensor,
+    WyBotWorkingTimeSensor,
     async_setup_entry,
     format_mac,
 )
@@ -22,7 +22,7 @@ from wybot.dp_models import (
     Battery,
     DockInfo,
     SolarDockBattery,
-    SolarEnergyHarvested,
+    WorkingTime,
 )
 
 from wybot_platform_helpers import add_entity, dp, make_coordinator, make_group
@@ -37,7 +37,7 @@ def _robot_dps():
 def _dock_dps():
     return {
         "221": dp(SolarDockBattery, id=221, type=0, len=3, data="01480a"),
-        "131": dp(SolarEnergyHarvested, id=131, type=2, len=4, data="e8030000"),
+        "131": dp(WorkingTime, id=131, type=2, len=4, data="e8030000"),
         "214": dp(DockInfo, id=214, type=4, len=1, data="05"),
     }
 
@@ -138,25 +138,25 @@ async def test_solar_dock_battery_dp_missing(hass: HomeAssistant) -> None:
     assert ent.native_value is None
 
 
-async def test_solar_energy_sensor(hass: HomeAssistant) -> None:
+async def test_working_time_sensor(hass: HomeAssistant) -> None:
     coord, _, _ = _coord(hass)
-    ent = WyBotSolarEnergySensor(idx=IDX, coordinator=coord)
+    ent = WyBotWorkingTimeSensor(idx=IDX, coordinator=coord)
     assert ent.native_value == 1000
-    assert ent.unique_id == "wybot_grp1_solar_energy"
-    assert ent.name == "Energy harvested"
+    assert ent.unique_id == "wybot_grp1_working_time"
+    assert ent.name == "Working time"
 
 
-async def test_solar_energy_no_data(hass: HomeAssistant) -> None:
+async def test_working_time_no_data(hass: HomeAssistant) -> None:
     coord, _, _ = _coord(hass)
-    ent = WyBotSolarEnergySensor(idx=IDX, coordinator=coord)
+    ent = WyBotWorkingTimeSensor(idx=IDX, coordinator=coord)
     ent._data = None
     assert ent.native_value is None
 
 
-async def test_solar_energy_dp_missing(hass: HomeAssistant) -> None:
+async def test_working_time_dp_missing(hass: HomeAssistant) -> None:
     group = make_group(device_dps={}, docker_dps={})
     coord, _ = make_coordinator(hass, {IDX: group})
-    ent = WyBotSolarEnergySensor(idx=IDX, coordinator=coord)
+    ent = WyBotWorkingTimeSensor(idx=IDX, coordinator=coord)
     assert ent.native_value is None
 
 
@@ -218,8 +218,8 @@ async def test_last_ble_communication_no_docker(hass: HomeAssistant) -> None:
     coord._last_ble_poll["dev1"] = now
     ent = WyBotLastBLECommunicationSensor(idx=IDX, coordinator=coord)
     assert ent.native_value == now
-    # No docker -> extra attrs empty.
-    assert ent.extra_state_attributes == {}
+    # A dockless robot (the F1) is tracked under its own device id.
+    assert ent.extra_state_attributes == {"ble_available": None}
 
 
 async def test_last_ble_communication_no_data(hass: HomeAssistant) -> None:
@@ -249,7 +249,7 @@ async def test_last_mqtt_communication_no_docker(hass: HomeAssistant) -> None:
     coord._last_mqtt_data["dev1"] = now
     ent = WyBotLastMQTTCommunicationSensor(idx=IDX, coordinator=coord)
     assert ent.native_value == now
-    assert ent.extra_state_attributes == {}
+    assert ent.extra_state_attributes == {"mqtt_connected": False}
 
 
 async def test_last_mqtt_communication_no_data(hass: HomeAssistant) -> None:
@@ -302,8 +302,10 @@ async def test_data_source_sensor_no_docker_uses_device(hass: HomeAssistant) -> 
     ent = WyBotDataSourceSensor(idx=IDX, coordinator=coord)
     assert ent.native_value == "Bluetooth"
     assert ent.icon == "mdi:bluetooth"
-    # No docker -> extra attrs empty.
-    assert ent.extra_state_attributes == {}
+    # A dockless robot (the F1) is tracked under its own device id.
+    attrs = ent.extra_state_attributes
+    assert attrs["ble_available"] is None
+    assert attrs["mqtt_connected"] is False
 
 
 async def test_data_source_sensor_no_data(hass: HomeAssistant) -> None:

--- a/tests/wybot_platform_helpers.py
+++ b/tests/wybot_platform_helpers.py
@@ -62,10 +62,18 @@ def dp(cls, **kwargs):
     return cls(DP(**kwargs))
 
 
-def make_group(device_dps=None, docker_dps=None, with_docker=True, name="My Pool"):
+def make_group(
+    device_dps=None,
+    docker_dps=None,
+    with_docker=True,
+    name="My Pool",
+    device_type=None,
+):
     """Build a real ``Group`` with typed DP instances attached."""
     data = deepcopy(GROUP_DATA)
     data["name"] = name
+    if device_type is not None:
+        data["device"]["deviceType"] = device_type
     if not with_docker:
         data["docker"] = None
     group = Group(**data)


### PR DESCRIPTION
## Summary

Add support for the **WyBot F1 pool skimmer** (model WYF1). The F1 has different hardware from the S2 Pro/DS20 dock: integrated solar panel (no dock), 3-byte battery format, F1-specific cleaning modes, and additional sensors (pH, sonar, in-water, auto-run, heavy dirt).

Closes #12.

## Background

Relates to #12 — @gk-lurker and another user both have F1 skimmers. @bassrock doesn't own an F1 and asked for PRs.

DP mappings were confirmed by reverse-engineering the WyBot Android APK (Flutter AOT-compiled `libapp.so` log strings) and a full BLE DP sweep (95 DPs discovered, 0-255 range).

## Changes

### `__init__.py`
- Add `Platform.SWITCH` to PLATFORMS list

### `vacuum.py`
- **Check cleaning status (DP 0) BEFORE dock status (DP 11)** — the F1 reports DP 11 = DOCKED even while cleaning (it has no real dock), so checking dock first causes it to show "docked" during active cleaning
- Add F1 cleaning modes to `fan_speed_list`: `["Standard", "Smart"]` when device type is `WYF1`
- Handle DP 0 = 0x0f (15) as IDLE/STANDBY (was returning `None` / UNKNOWN)
- `async_set_fan_speed` sends correct DP 1 hex values for F1 modes (14=Smart, 15=Standard)

### `sensor.py`
New F1-specific sensors:
- **F1SolarBatterySensor** — reads DP 50 middle byte (F1 3-byte battery format)
- **F1CleaningModeSensor** — shows "Smart" or "Standard" from DP 1

BLE-only sensors (disabled by default, can be enabled by users with BLE coverage):
- **F1RuntimeSensor** — total runtime from DP 25/111
- **F1CycleRuntimeSensor** — cycle runtime from DP 55/129
- **F1WaterTempSensor** — water temperature from DP 30
- **F1TotalEnergySensor** — total energy from DP 34
- **F1MotorPWMSensor** — motor PWM values from DP 81-85
- **F1HeavyDirtSensor** — heavy dirt mode from DP 145
- **F1InWaterSensor** — in-water state from DP 212
- **F1SonarSensor** — sonar state from DP 209
- **F1PhSensor** — pH value from DP 142

Modified existing sensors:
- **SolarDockBatterySensor** — F1 fallback: reads DP 50 middle byte when DP 221 unavailable
- **SolarEnergySensor** — relabeled to "Working Time" (DP 131 is seconds, not Wh per APK)
- **Diagnostic sensors** — use `device.device_id` instead of empty `docker.docker_id` (F1 has a phantom dock entry with empty id)

### `binary_sensor.py`
- **DockChargingBinarySensor** — F1 fallback: uses DP 50 `charge_state == CHARGING` when DP 222 (SolarStatus) unavailable
- **WyBotFullyChargedBinarySensor** (new) — on when `charge_state == CHARGED` (DP 50)

### `switch.py` (new file)
- **WyBotF1AutoRunSwitch** — toggle auto-run mode (DP 207 / 0xCF)
  - `async_turn_on`: sends `GenericDP(id=207, type=4, len=1, data="01")`
  - `async_turn_off`: sends `GenericDP(id=207, type=4, len=1, data="00")`
  - APK: `"parseBLEData: getAutoRunMode DP_ID_AUTO_RUN 0XCF mode: "`

## F1 vs DS20 Comparison

| Feature | DS20 (S2 Pro) | F1 |
|---|---|---|
| Dock | Separate DS20 solar dock | Integrated solar panel (no dock) |
| Battery DP (50) | 2 bytes `[charge][robot%]` | 3 bytes `[charge][solar%][robot%]` |
| Solar battery | DP 221 (3-byte) | DP 50 byte 1 (middle of 3-byte battery) |
| Solar charging | DP 222 (1-byte bool) | DP 50 byte 0 (charge_state = CHARGING) |
| Cleaning modes | 0-6 (Floor, Wall, etc.) | 14=Smart, 15=Standard |
| Idle status (DP 0) | Not reported | 0x0f (15) = IDLE/STANDBY |
| Dock status (DP 11) | Accurate | Reports DOCKED even while cleaning |
| pH sensor | No | Yes (DP 142) |
| Sonar | No | Yes (DP 209) |
| In-water detection | No | Yes (DP 212) |
| Auto-run mode | No | Yes (DP 207) |
| Heavy dirt mode | No | Yes (DP 145) |
| Total DPs | ~16 | 95 via BLE, 65 via MQTT |

## BLE vs MQTT

The F1 delivers 95 DPs via BLE and 65 via MQTT (cloud). BLE is a strict superset — all MQTT DPs have identical values to their BLE counterparts. 18 DPs are BLE-only (including pH, sonar, in-water, motor PWM, and the cleaning map). Most users will connect via MQTT cloud only, so BLE-only sensors are disabled by default.

## APK-Confirmed DP Map

| DP | Hex | Name | Type | Source |
|---|---|---|---|---|
| 0 | 0x00 | Running mode | enum | `"DP_ID:0X00, running mode value"` |
| 1 | 0x01 | Cleaning mode | enum | `"DP_ID: 0X01"` ( CleaningMode class) |
| 50 | 0x32 | Battery | raw | `"DP_ID: 0X32 device battery"` |
| 70 | 0x46 | System time | LE int | `"DP_ID_SYSTEM_TIME 0x46 sysTime"` |
| 131 | 0x83 | Working time | LE int | `"DP_ID: 0X83 working time"` |
| 142 | 0x8E | pH data | raw | `"PH_DATA:0X8E, pHvalue: "` + `"tempValue: "` |
| 145 | 0x91 | Heavy dirt mode | bool | `"DP_ID:OX91 heavyDirt mode: "` |
| 206 | 0xCE | Cleaning depth range | raw | `"DP_ID_CLEANING_DEPTH_RANGE 0xCE min: "` |
| 207 | 0xCF | Auto run mode | bool | `"DP_ID_AUTO_RUN 0XCF mode: "` |
| 209 | 0xD1 | Sonar state | bool | `"DP_ID: 0XD1 sona state"` |
| 212 | 0xD4 | In water state | bool | `"DP_ID: 0XD4 inWaterState"` |
| 221 | 0xDD | Charging state | enum | `"DP_ID:DD charging state"` |
| 222 | 0xDE | Low power | bool | `"DP_ID:DE lowPower value"` |

## Independence from pywybot PR

This PR works whether or not the companion [pywybot PR](https://github.com/bassrock/pywybot/pull/1) is merged. All F1 sensors read DPs by raw ID from the device's `dps` dict, not through typed DP classes from pywybot. The two PRs can be merged at different release cycles.

## Testing

Tested on a live F1 skimmer over 3 days:
- MQTT cloud connection: 6 DPs (battery, cleaning status, mode, dock, schedule, auto-run)
- BLE direct connection: 95 DPs (full DP sweep)
- Mode switching: confirmed DP 1 values (14=Smart, 15=Standard)
- All BLE and MQTT data values matched identically